### PR TITLE
Implement immediate sync when form submitted

### DIFF
--- a/app.py
+++ b/app.py
@@ -945,9 +945,11 @@ def index():
         SYNC_LIKED_LISTS = request.form.get("liked_lists") is not None
         SYNC_WATCHLISTS = request.form.get("watchlists") is not None
         scheduler.remove_all_jobs()
+        # Run an immediate synchronization and then schedule the next one
+        sync()
         scheduler.add_job(sync, "interval", minutes=minutes, id="sync_job")
         return redirect(
-            url_for("index", message="Sync settings updated successfully!", mtype="success")
+            url_for("index", message="Sync started successfully!", mtype="success")
         )
 
     message = request.args.get("message")


### PR DESCRIPTION
## Summary
- run a sync right away when hitting Sync

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684560dcd91c832e89d3d427e18bcc6c