### PR TITLE
Add Docker Hub compose and rename local compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,18 @@ TRAKT_CLIENT_SECRET=YOUR_TRAKT_CLIENT_SECRET
 TZ=Europe/Madrid
 ```
 
-3. Build and start the application using Docker Compose:
+3. Start the application using Docker Compose. The default `docker-compose.yml`
+   pulls the image from Docker Hub:
 
 ```
-docker-compose up --build
+docker-compose up -d
+```
+
+If you prefer to build the image locally use the `docker-compose-local.yml`
+file:
+
+```
+docker-compose -f docker-compose-local.yml up --build
 ```
 
 4. Visit `http://localhost:5000` in your browser. You can adjust the sync interval on the page and also stop the synchronization job at any time using the **Stop Sync** button. The background job starts automatically when the container is running.

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   app:
-    image: drakonis96/plexytrack
+    build: .
     ports:
       - "5000:5000"
     env_file:


### PR DESCRIPTION
## Summary
- add new `docker-compose.yml` that uses `drakonis96/plexytrack` image from Docker Hub
- rename original compose file to `docker-compose-local.yml`
- document using both compose files in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68456673948c832ebc051020e022e3bc