### PR TITLE
Fix Plex watchlist sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -867,7 +867,8 @@ def sync_collections_to_trakt(plex, headers):
 
 def sync_watchlist(plex, headers, plex_history, trakt_history):
     """Two-way sync of Plex and Trakt watchlists."""
-    account = plex.account()
+    # Use MyPlexAccount to access watchlist API
+    account = plex.myPlexAccount()
     try:
         plex_watch = account.watchlist()
     except Exception as exc:


### PR DESCRIPTION
## Summary
- use `plex.myPlexAccount()` to access watchlist API

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68456c6d0804832eb8098a3dfdb5f742