### PR TITLE
Improve sync UX

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -160,3 +160,9 @@ button:hover {
     max-width: 120px;
     height: auto;
 }
+
+.next-run {
+    margin-top: 15px;
+    text-align: center;
+    font-size: 0.9em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,6 +50,10 @@
     </form>
     </div>
 
+    {% if next_run %}
+    <div class="next-run">Next sync: {{ next_run }}</div>
+    {% endif %}
+
     <div id="confirmationMessage" class="confirmation-message{% if mtype == 'success' %} success{% elif mtype == 'stopped' %} stopped{% endif %}" {% if not message %}style="display:none;"{% endif %}>{{ message }}</div>
 
     <script>


### PR DESCRIPTION
## Summary
- run sync job asynchronously so the page loads faster
- show next scheduled sync time in the interface

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456fcc3d28832e85f11d2afe5e0a98