### PR TITLE
Add Trakt backup feature

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -64,6 +64,15 @@ button:hover {
     filter: brightness(0.95);
 }
 
+.button {
+    background-color: #43a047;
+    color: #fff;
+    padding: 10px 15px;
+    border-radius: 4px;
+    text-decoration: none;
+    display: inline-block;
+}
+
 .options {
     display: flex;
     flex-direction: column;
@@ -165,4 +174,22 @@ button:hover {
     margin-top: 15px;
     text-align: center;
     font-size: 0.9em;
+}
+
+.nav {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.nav a {
+    text-decoration: none;
+    color: #000;
+    padding: 8px 16px;
+    border-bottom: 2px solid transparent;
+}
+
+.nav a.active {
+    border-color: #43a047;
 }

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>PlexyTrack Backup</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+    <div class="nav">
+        <a href="{{ url_for('index') }}">Sync</a>
+        <a href="{{ url_for('backup_page') }}" class="active">Backup</a>
+    </div>
+    <h1>PlexyTrack Backup</h1>
+    <div class="form-bordered" style="text-align:center;">
+        <a href="{{ url_for('download_backup') }}" class="button" style="margin-bottom:15px;">Download Backup</a>
+        <form method="post" action="{{ url_for('restore_backup_route') }}" enctype="multipart/form-data">
+            <input type="file" name="backup" accept="application/json" class="input-bordered">
+            <button type="submit">Restore Backup</button>
+        </form>
+    </div>
+    <div id="confirmationMessage" class="confirmation-message{% if mtype == 'success' %} success{% elif mtype == 'error' %} stopped{% endif %}" {% if not message %}style="display:none;"{% endif %}>{{ message }}</div>
+    <script>
+        const msg = document.getElementById('confirmationMessage');
+        if (msg.textContent.trim() !== '') {
+            setTimeout(function() { msg.style.display = 'none'; }, 3000);
+        }
+    </script>
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,10 @@
 </head>
 <body>
 <div class="container">
+    <div class="nav">
+        <a href="{{ url_for('index') }}" class="active">Sync</a>
+        <a href="{{ url_for('backup_page') }}">Backup</a>
+    </div>
     <h1>PlexyTrack</h1>
     <h2><em>Sync your Plex and Trakt libraries</em></h2>
     <div class="form-bordered">


### PR DESCRIPTION
## Summary
- add navigation tabs to switch between Sync and Backup pages
- implement backup download and restore functions in Flask app
- style navigation bar and buttons
- create Backup page template

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c84fcbc0832e869581742a9ed31c