### PR TITLE
Fix footer text on sync page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -78,7 +78,7 @@
         </main>
 
         <footer class="app-footer">
-            <p>&copy; 2025 PlexyTrack. All rights reserved.</p>
+            <p>MIT License. by Drakonis96</p>
         </footer>
     </div>
 


### PR DESCRIPTION
## Summary
- update footer on the sync page to mention MIT license

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e6f55eb8832eac9700974bc00a78