### PR TITLE
Add Simkl backup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you mark a list as liked on Trakt, PlexyTrack will create a Plex collection w
 
 ### Backup and restore
 
-From the web interface you can download a backup file containing your Trakt history, watchlist and ratings. This JSON file can be uploaded again to restore your data at any time. Creating a backup is recommended before starting synchronization for the first time.
+From the web interface you can download a backup file containing your Trakt or Simkl history, watchlist and ratings. This JSON file can be uploaded again to restore your data at any time. Creating a backup is recommended before starting synchronization for the first time.
 
 ### Live sync
 

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -23,12 +23,16 @@
         <main class="content-area">
             <section class="backup-section card">
                 <h2><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM11 7H13V11H17V13H13V17H11V13H7V11H11V7Z"></path></svg> Backup & Restore</h2>
-                <p class="description">Backup your Trakt history, ratings, and watchlist, or restore from a previous backup.</p>
+                <p class="description">Backup your Trakt or Simkl history, ratings, and watchlist, or restore from a previous backup.</p>
                 
                 <div class="backup-actions">
                     <a href="{{ url_for('download_backup') }}" class="button primary">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 10.5858L14.8284 7.75736L16.2426 9.17157L12 13.4142L7.75736 9.17157L9.17157 7.75736L12 10.5858ZM12 15V17H17V15H12Z"></path></svg>
-                        Download Backup
+                        Download Trakt Backup
+                    </a>
+                    <a href="{{ url_for('download_simkl_backup') }}" class="button primary">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 10.5858L14.8284 7.75736L16.2426 9.17157L12 13.4142L7.75736 9.17157L9.17157 7.75736L12 10.5858ZM12 15V17H17V15H12Z"></path></svg>
+                        Download Simkl Backup
                     </a>
                 </div>
 
@@ -39,7 +43,18 @@
                     </div>
                     <button type="submit" class="button secondary">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 13.4142L9.17157 16.2426L7.75736 14.8284L12 10.5858L16.2426 14.8284L14.8284 16.2426L12 13.4142ZM12 7V9H7V7H12Z"></path></svg>
-                        Restore Backup
+                        Restore Trakt Backup
+                    </button>
+                </form>
+
+                <form method="post" action="{{ url_for('restore_simkl_backup_route') }}" enctype="multipart/form-data" class="restore-form">
+                    <div class="form-group">
+                        <label for="simklBackupFile">Restore from Backup File:</label>
+                        <input type="file" id="simklBackupFile" name="backup" accept="application/json" class="form-input-file">
+                    </div>
+                    <button type="submit" class="button secondary">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 13.4142L9.17157 16.2426L7.75736 14.8284L12 10.5858L16.2426 14.8284L14.8284 16.2426L12 13.4142ZM12 7V9H7V7H12Z"></path></svg>
+                        Restore Simkl Backup
                     </button>
                 </form>
             </section>


### PR DESCRIPTION
## Summary
- allow choosing Simkl when downloading or restoring backups
- implement Simkl backup endpoints in the Flask app
- support configurable base URL in backup helpers
- update docs

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847f576d4b0832ea6c85a1a3cf9b36d