### PR TITLE
Handle null Simkl history

### DIFF
--- a/app.py
+++ b/app.py
@@ -587,7 +587,7 @@ def get_trakt_history(
         )
         data = resp.json()
         if not isinstance(data, list):
-            logger.error("Unexpected Simkl history format: %r", data)
+            logger.error("Unexpected Trakt history format: %r", data)
             break
         if not data:
             break
@@ -692,7 +692,8 @@ def get_simkl_history(
         params={"extended": "full", "episode_watched_at": "yes"},
     )
     data = resp.json()
-
+    if data is None:
+        data = {}
     if not isinstance(data, dict):
         logger.error("Unexpected Simkl history format: %r", data)
         return movies, episodes


### PR DESCRIPTION
## Summary
- fix unexpected 'Simkl history format: None' by handling null response
- correct log message when Trakt history returns unexpected data

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68487e053e60832e8554c40c5f20eb72