### PR TITLE
Add clear config buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ interface will guide you through authorizing the app and will store the tokens
 for you.
 
 Authorization codes will appear in the **OAuth** tab and can then be entered from the **Config.** tab, which shows whether each service is already configured.
+If you want to remove saved tokens, the Config page also provides **Clear Config** buttons for both Trakt and Simkl.
 
 
 When specifying a custom redirect URI for either service, ensure the same

--- a/app.py
+++ b/app.py
@@ -1915,6 +1915,34 @@ def authorize_service(service: str):
     )
 
 
+@app.route("/clear/<service>", methods=["POST"])
+def clear_service(service: str):
+    """Remove stored tokens for the given service."""
+    service = service.lower()
+    if service == "trakt":
+        os.environ.pop("TRAKT_ACCESS_TOKEN", None)
+        os.environ.pop("TRAKT_REFRESH_TOKEN", None)
+        if os.path.exists(TOKEN_FILE):
+            try:
+                os.remove(TOKEN_FILE)
+                logger.info("Removed Trakt token file")
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Failed to remove Trakt token file: %s", exc)
+        if SYNC_PROVIDER == "trakt":
+            save_provider("none")
+    elif service == "simkl":
+        os.environ.pop("SIMKL_ACCESS_TOKEN", None)
+        if os.path.exists(SIMKL_TOKEN_FILE):
+            try:
+                os.remove(SIMKL_TOKEN_FILE)
+                logger.info("Removed Simkl token file")
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Failed to remove Simkl token file: %s", exc)
+        if SYNC_PROVIDER == "simkl":
+            save_provider("none")
+    return redirect(url_for("config_page"))
+
+
 @app.route("/stop", methods=["POST"])
 def stop():
     stop_scheduler()

--- a/templates/config.html
+++ b/templates/config.html
@@ -31,6 +31,9 @@
                 <div class="status-message error">Trakt not configured</div>
                 {% endif %}
                 <a href="{{ url_for('authorize_service', service='trakt') }}" class="button primary" style="margin-top:10px;">Configure</a>
+                <form method="post" action="{{ url_for('clear_service', service='trakt') }}" class="stop-form">
+                    <button type="submit" class="button secondary">Clear Config</button>
+                </form>
             </section>
 
             <section class="card">
@@ -41,6 +44,9 @@
                 <div class="status-message error">Simkl not configured</div>
                 {% endif %}
                 <a href="{{ url_for('authorize_service', service='simkl') }}" class="button primary" style="margin-top:10px;">Configure</a>
+                <form method="post" action="{{ url_for('clear_service', service='simkl') }}" class="stop-form">
+                    <button type="submit" class="button secondary">Clear Config</button>
+                </form>
             </section>
 
             <section class="card">


### PR DESCRIPTION
## Summary
- allow removing stored tokens via new `clear_service` route
- add `Clear Config` buttons for Trakt and Simkl on the configuration page
- document the new buttons in README

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a17d3574832ead53d183ab46b367