### PR TITLE
Fix Simkl token initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -2131,6 +2131,7 @@ def stop_scheduler():
 if __name__ == "__main__":
     logger.info("Starting PlexyTrackt application")
     load_trakt_tokens()
+    load_simkl_tokens()
     load_provider()
     start_scheduler()
     app.run(host="0.0.0.0", port=5030)


### PR DESCRIPTION
## Summary
- load Simkl token at startup

## Testing
- `python -m py_compile app.py`
- `pip install -q Flask requests APScheduler 'plexapi>=4.15,<5'`


------
https://chatgpt.com/codex/tasks/task_e_6848a61529c8832eb9b9b1259a400b31