### PR TITLE
Fix duplicated logs on sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -2210,4 +2210,5 @@ if __name__ == "__main__":
     load_simkl_tokens()
     load_provider()
     start_scheduler()
-    app.run(host="0.0.0.0", port=5030)
+    # Disable Flask's auto-reloader to avoid duplicate logs
+    app.run(host="0.0.0.0", port=5030, use_reloader=False)


### PR DESCRIPTION
## Summary
- avoid Flask autoreloader causing duplicate logs

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848cb9a1a54832eaf84171c771c294b