### PR TITLE
Fix Simkl logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -777,7 +777,8 @@ def get_simkl_history(
         params={"extended": "full", "episode_watched_at": "yes"},
     )
     data = resp.json()
-    logger.info(f"Simkl API response: {data}")
+    # Avoid logging the full API response to prevent cluttering logs
+    logger.debug("Simkl history retrieved from API")
     if data is None:
         data = {}
     if not isinstance(data, dict):


### PR DESCRIPTION
## Summary
- hide verbose Simkl API response from logs

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848d53a3d2c832ea4959185fd8913d0