### PR TITLE
Fix Simkl sync endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you don't already have the Trakt or Simkl credentials, please see the next se
 ### Collections and watchlists
 
 If you mark a list as liked on Trakt, PlexyTrack will create a Plex collection with the same name and add the matching movies or shows found in your library. Likewise, any collection created in Plex will be mirrored as a list on Trakt. Watchlists are also kept in sync both ways, so adding or removing an item in one platform is reflected in the other.
-When the Simkl provider is selected, your Plex library is copied to the **My TV Shows** and **My Movies** sections on Simkl and Plex collections are mirrored as Simkl lists.
+When the Simkl provider is selected, your Plex library is added to your completed history on Simkl and Plex collections are mirrored as Simkl lists.
 
 ### Backup and restore
 


### PR DESCRIPTION
## Summary
- mark movies and shows complete on Simkl via `/sync/history`
- sync entire Plex library to Simkl history instead of using undocumented endpoints
- update docs about how the library is synced

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848d61bb9d4832e85f6a2238c1028cc