### PR TITLE
Fix missing simkl variables in connection test

### DIFF
--- a/app.py
+++ b/app.py
@@ -1800,6 +1800,9 @@ def test_connections() -> bool:
     trakt_token = os.environ.get("TRAKT_ACCESS_TOKEN")
     trakt_client_id = os.environ.get("TRAKT_CLIENT_ID")
     trakt_enabled = SYNC_PROVIDER == "trakt" and bool(trakt_token and trakt_client_id)
+    simkl_token = os.environ.get("SIMKL_ACCESS_TOKEN")
+    simkl_client_id = os.environ.get("SIMKL_CLIENT_ID")
+    simkl_enabled = SYNC_PROVIDER == "simkl" and bool(simkl_token and simkl_client_id)
 
     if not all([plex_baseurl, plex_token]):
         logger.error("Missing environment variables for Plex.")


### PR DESCRIPTION
## Summary
- ensure Simkl variables are defined in `test_connections`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684954d98b2c832ea47fc97527b56fc5