### PR TITLE
Refactor provider logic into modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,51 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from plexapi.server import PlexServer
 from plexapi.exceptions import BadRequest, NotFound
 
+from utils import (
+    to_iso_z,
+    normalize_year,
+    _parse_guid_value,
+    best_guid,
+    imdb_guid,
+    get_show_from_library,
+    find_item_by_guid,
+    ensure_collection,
+    movie_key,
+    guid_to_ids,
+    valid_guid,
+    trakt_movie_key,
+    episode_key,
+    trakt_episode_key,
+    simkl_episode_key,
+)
+from plex_utils import get_plex_history, update_plex
+from trakt_utils import (
+    load_trakt_tokens,
+    save_trakt_tokens,
+    exchange_code_for_tokens,
+    refresh_trakt_token,
+    trakt_request,
+    get_trakt_history,
+    update_trakt,
+    sync_collection,
+    sync_ratings,
+    sync_liked_lists,
+    sync_collections_to_trakt,
+    sync_watchlist,
+    fetch_trakt_history_full,
+    fetch_trakt_ratings,
+    fetch_trakt_watchlist,
+    restore_backup,
+)
+from simkl_utils import (
+    load_simkl_tokens,
+    save_simkl_token,
+    exchange_code_for_simkl_tokens,
+    simkl_request,
+    get_simkl_history,
+    update_simkl,
+)
+
 # --------------------------------------------------------------------------- #
 # LOGGING
 # --------------------------------------------------------------------------- #

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -1,0 +1,233 @@
+import logging
+from typing import Dict, Optional, Set, Tuple, Union
+
+from .utils import (
+    _parse_guid_value,
+    get_show_from_library,
+    imdb_guid,
+    normalize_year,
+    to_iso_z,
+    valid_guid,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_plex_history(plex) -> Tuple[
+    Dict[str, Dict[str, Optional[str]]],
+    Dict[str, Dict[str, Optional[str]]],
+]:
+    """Return watched movies and episodes from Plex keyed by GUID."""
+    movies: Dict[str, Dict[str, Optional[str]]] = {}
+    episodes: Dict[str, Dict[str, Optional[str]]] = {}
+    show_guid_cache: Dict[str, Optional[str]] = {}
+
+    logger.info("Fetching Plex history…")
+    for entry in plex.history():
+        watched_at = to_iso_z(getattr(entry, "viewedAt", None))
+
+        if entry.type == "movie":
+            try:
+                item = entry.source() or plex.fetchItem(entry.ratingKey)
+            except Exception as exc:
+                logger.debug("Failed to fetch movie %s from Plex: %s", entry.ratingKey, exc)
+                continue
+            title = item.title
+            year = normalize_year(getattr(item, "year", None))
+            guid = imdb_guid(item)
+            if not guid:
+                continue
+            if guid not in movies:
+                movies[guid] = {
+                    "title": title,
+                    "year": year,
+                    "watched_at": watched_at,
+                    "guid": guid,
+                }
+        elif entry.type == "episode":
+            season = getattr(entry, "parentIndex", None)
+            number = getattr(entry, "index", None)
+            show = getattr(entry, "grandparentTitle", None)
+            try:
+                item = entry.source() or plex.fetchItem(entry.ratingKey)
+            except Exception as exc:
+                logger.debug("Failed to fetch episode %s from Plex: %s", entry.ratingKey, exc)
+                item = None
+            if item:
+                season = season or item.seasonNumber
+                number = number or item.index
+                show = show or item.grandparentTitle
+                guid = imdb_guid(item)
+            else:
+                guid = None
+            if None in (season, number, show):
+                continue
+            code = f"S{int(season):02d}E{int(number):02d}"
+
+            series_guid: Optional[str] = None
+            if item is not None:
+                gp_guid_raw = getattr(item, "grandparentGuid", None)
+                if gp_guid_raw:
+                    series_guid = _parse_guid_value(gp_guid_raw)
+            if series_guid is None and show in show_guid_cache:
+                series_guid = show_guid_cache[show]
+            if series_guid is None and show:
+                series_obj = get_show_from_library(plex, show)
+                series_guid = imdb_guid(series_obj) if series_obj else None
+                show_guid_cache[show] = series_guid
+
+            if series_guid and valid_guid(series_guid):
+                key = (series_guid, code)
+            elif guid:
+                key = guid
+            else:
+                key = (show.lower() if show else "", code)
+            if key not in episodes:
+                episodes[key] = {
+                    "show": show,
+                    "code": code,
+                    "watched_at": watched_at,
+                    "guid": guid,
+                }
+
+    logger.info("Fetching watched flags from Plex library…")
+    for section in plex.library.sections():
+        try:
+            if section.type == "movie":
+                for item in section.search(viewCount__gt=0):
+                    title = item.title
+                    year = normalize_year(getattr(item, "year", None))
+                    guid = imdb_guid(item)
+                    if guid and guid not in movies:
+                        movies[guid] = {
+                            "title": title,
+                            "year": year,
+                            "watched_at": to_iso_z(getattr(item, "lastViewedAt", None)),
+                            "guid": guid,
+                        }
+            elif section.type == "show":
+                for ep in section.searchEpisodes(viewCount__gt=0):
+                    code = f"S{int(ep.seasonNumber):02d}E{int(ep.episodeNumber):02d}"
+                    guid = imdb_guid(ep)
+                    show_title = getattr(ep, "grandparentTitle", None)
+                    if guid:
+                        key: Union[str, Tuple[str, str]] = guid
+                    else:
+                        series_guid: Optional[str] = None
+                        gp_guid_raw = getattr(ep, "grandparentGuid", None)
+                        if gp_guid_raw:
+                            series_guid = _parse_guid_value(gp_guid_raw)
+                        if series_guid is None and show_title and show_title in show_guid_cache:
+                            series_guid = show_guid_cache[show_title]
+                        if series_guid is None and show_title:
+                            series_obj = get_show_from_library(plex, show_title)
+                            series_guid = imdb_guid(series_obj) if series_obj else None
+                            show_guid_cache[show_title] = series_guid
+                        if series_guid and valid_guid(series_guid):
+                            key = (series_guid, code)
+                        else:
+                            key = (show_title.lower() if show_title else "", code)
+                    if key not in episodes:
+                        episodes[key] = {
+                            "show": show_title,
+                            "code": code,
+                            "watched_at": to_iso_z(getattr(ep, "lastViewedAt", None)),
+                            "guid": guid,
+                        }
+        except Exception as exc:
+            logger.debug("Failed fetching watched items from section %s: %s", section.title, exc)
+
+    return movies, episodes
+
+
+def update_plex(
+    plex,
+    movies: Set[Tuple[str, Optional[int], Optional[str]]],
+    episodes: Set[Tuple[str, str, Optional[Union[str, Tuple[str, str]]]]],
+) -> None:
+    """Mark items as watched in Plex when missing."""
+    movie_count = 0
+    episode_count = 0
+
+    for title, year, guid in movies:
+        if guid and valid_guid(guid):
+            try:
+                item = plex.fetchItem(guid)
+                if getattr(item, "isWatched", lambda: bool(getattr(item, "viewCount", 0)))():
+                    continue
+                item.markWatched()
+                movie_count += 1
+                continue
+            except Exception as exc:
+                logger.debug("GUID fetch failed for %s: %s", guid, exc)
+
+        found = None
+        for section in plex.library.sections():
+            if section.type != "movie":
+                continue
+            try:
+                results = section.search(title=title)
+                for candidate in results:
+                    if year is None or normalize_year(getattr(candidate, "year", None)) == normalize_year(year):
+                        found = candidate
+                        break
+                if found:
+                    break
+            except Exception as exc:
+                logger.debug("Search failed in section %s: %s", section.title, exc)
+
+        if not found:
+            logger.debug("Movie not found in Plex library: %s (%s)", title, year)
+            continue
+
+        try:
+            if getattr(found, "isWatched", lambda: bool(getattr(found, "viewCount", 0)))():
+                continue
+            found.markWatched()
+            movie_count += 1
+        except Exception as exc:
+            logger.debug("Failed to mark movie '%s' as watched: %s", found.title, exc)
+
+    for show_title, code, key in episodes:
+        guid: Optional[str] = None
+        if isinstance(key, str):
+            guid = key if valid_guid(key) else None
+        elif isinstance(key, tuple) and key and isinstance(key[0], str):
+            guid = key[0] if valid_guid(key[0]) else None
+
+        if guid:
+            try:
+                item = plex.fetchItem(guid)
+                if getattr(item, "isWatched", lambda: bool(getattr(item, "viewCount", 0)))():
+                    continue
+                item.markWatched()
+                episode_count += 1
+                continue
+            except Exception as exc:
+                logger.debug("GUID fetch failed for %s: %s", guid, exc)
+
+        try:
+            season_num, episode_num = map(int, code.upper().lstrip("S").split("E"))
+        except ValueError:
+            logger.debug("Invalid episode code format: %s", code)
+            continue
+
+        show_obj = get_show_from_library(plex, show_title)
+        if not show_obj:
+            logger.debug("Show not found in Plex library: %s", show_title)
+            continue
+
+        try:
+            season_obj = show_obj.season(season_num)
+            ep_obj = season_obj.episode(episode_num)
+            if getattr(ep_obj, "isWatched", lambda: bool(getattr(ep_obj, "viewCount", 0)))():
+                continue
+            ep_obj.markWatched()
+            episode_count += 1
+        except Exception as exc:
+            logger.debug("Failed marking episode %s - %s as watched: %s", show_title, code, exc)
+
+    if movie_count or episode_count:
+        logger.info("Marked %d movies and %d episodes as watched in Plex", movie_count, episode_count)
+    else:
+        logger.info("Nothing new to send to Plex.")

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -1,0 +1,220 @@
+import json
+import logging
+import os
+from typing import Dict, List, Optional, Tuple
+
+import requests
+
+from .utils import guid_to_ids, normalize_year, simkl_episode_key, to_iso_z
+
+logger = logging.getLogger(__name__)
+
+SIMKL_TOKEN_FILE = "simkl_tokens.json"
+
+
+def load_simkl_tokens() -> None:
+    if os.environ.get("SIMKL_ACCESS_TOKEN"):
+        return
+    if os.path.exists(SIMKL_TOKEN_FILE):
+        try:
+            with open(SIMKL_TOKEN_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            os.environ["SIMKL_ACCESS_TOKEN"] = data.get("access_token", "")
+            logger.info("Loaded Simkl token from %s", SIMKL_TOKEN_FILE)
+        except Exception as exc:
+            logger.error("Failed to load Simkl token: %s", exc)
+
+
+def save_simkl_token(access_token: str) -> None:
+    try:
+        with open(SIMKL_TOKEN_FILE, "w", encoding="utf-8") as f:
+            json.dump({"access_token": access_token}, f, indent=2)
+        logger.info("Saved Simkl token to %s", SIMKL_TOKEN_FILE)
+    except Exception as exc:
+        logger.error("Failed to save Simkl token: %s", exc)
+
+
+def exchange_code_for_simkl_tokens(code: str, redirect_uri: str) -> Optional[dict]:
+    client_id = os.environ.get("SIMKL_CLIENT_ID")
+    client_secret = os.environ.get("SIMKL_CLIENT_SECRET")
+    if not all([code, client_id, client_secret]):
+        logger.error("Missing code or Simkl client credentials.")
+        return None
+
+    payload = {
+        "code": code,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+        "grant_type": "authorization_code",
+    }
+    try:
+        resp = requests.post("https://api.simkl.com/oauth/token", json=payload, timeout=30)
+        resp.raise_for_status()
+    except Exception as exc:
+        logger.error("Failed to obtain Simkl token: %s", exc)
+        return None
+
+    data = resp.json()
+    os.environ["SIMKL_ACCESS_TOKEN"] = data["access_token"]
+    save_simkl_token(data["access_token"])
+    logger.info("Simkl token obtained via authorization code")
+    return data
+
+
+def simkl_request(method: str, endpoint: str, headers: dict, *, retries: int = 2, timeout: int = 30, **kwargs) -> requests.Response:
+    url = f"https://api.simkl.com{endpoint}"
+    if "timeout" in kwargs:
+        timeout = kwargs.pop("timeout")
+    attempt = 0
+    while True:
+        try:
+            resp = requests.request(method, url, headers=headers, timeout=timeout, **kwargs)
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.ReadTimeout as exc:
+            if attempt >= retries:
+                logger.error("Simkl ReadTimeout after %d attempts (%d s).", attempt + 1, timeout)
+                raise
+            attempt += 1
+            timeout *= 2
+            logger.warning(
+                "Simkl request %s %s timed out (%s). Retrying (%d/%d) with timeout=%ds…",
+                method.upper(), endpoint, exc, attempt, retries, timeout,
+            )
+        except requests.exceptions.RequestException:
+            raise
+
+
+def simkl_search_ids(headers: dict, title: str, *, is_movie: bool = True, year: Optional[int] = None) -> Dict[str, Union[str, int]]:
+    endpoint = "/search/movies" if is_movie else "/search/shows"
+    params = {"q": title, "limit": 1}
+    if year and is_movie:
+        params["year"] = year
+    try:
+        resp = simkl_request("GET", endpoint, headers, params=params)
+        data = resp.json()
+    except Exception as exc:
+        logger.debug("Simkl search failed for '%s': %s", title, exc)
+        return {}
+    if not isinstance(data, list) or not data:
+        return {}
+    ids = data[0].get("ids", {}) or {}
+    for k, v in list(ids.items()):
+        try:
+            ids[k] = int(v) if str(v).isdigit() else v
+        except Exception:
+            pass
+    return ids
+
+
+def simkl_movie_key(m: dict) -> Optional[str]:
+    ids = m.get("ids", {})
+    if ids.get("imdb"):
+        return f"imdb://{ids['imdb']}"
+    if ids.get("tmdb"):
+        return f"tmdb://{ids['tmdb']}"
+    if ids.get("tvdb"):
+        return f"tvdb://{ids['tvdb']}"
+    if ids.get("anidb"):
+        return f"anidb://{ids['anidb']}"
+    return None
+
+
+def get_simkl_history(headers: dict) -> Tuple[Dict[str, Tuple[str, Optional[int], Optional[str]]], Dict[str, Tuple[str, str, Optional[str]]]]:
+    movies: Dict[str, Tuple[str, Optional[int], Optional[str]]] = {}
+    episodes: Dict[str, Tuple[str, str, Optional[str]]] = {}
+
+    page = 1
+    logger.info("Fetching Simkl watch history…")
+    while True:
+        resp = simkl_request("GET", "/sync/history", headers, params={"page": page, "limit": 100, "type": "movies"})
+        data = resp.json()
+        if not isinstance(data, list) or not data:
+            break
+        for item in data:
+            m = item.get("movie", {})
+            guid = simkl_movie_key(m)
+            if not guid:
+                continue
+            if guid not in movies:
+                movies[guid] = (m.get("title"), normalize_year(m.get("year")), item.get("watched_at"))
+        page += 1
+
+    page = 1
+    logger.info("Fetching Simkl episode history…")
+    while True:
+        resp = simkl_request("GET", "/sync/history", headers, params={"page": page, "limit": 100, "type": "episodes"})
+        data = resp.json()
+        if not isinstance(data, list) or not data:
+            break
+        for item in data:
+            e = item.get("episode", {})
+            show = item.get("show", {})
+            guid = simkl_episode_key(show, e)
+            if not guid:
+                continue
+            if guid not in episodes:
+                episodes[guid] = (show.get("title"), f"S{e.get('season', 0):02d}E{e.get('number', 0):02d}", item.get("watched_at"))
+        page += 1
+
+    return movies, episodes
+
+
+def update_simkl(headers: dict, movies: List[Tuple[str, Optional[int], Optional[str], Optional[str]]], episodes: List[Tuple[str, str, Optional[str], Optional[str]]]) -> None:
+    payload = {}
+    if movies:
+        payload["movies"] = []
+        for title, year, guid, watched_at in movies:
+            item = {"title": title, "year": normalize_year(year)}
+            ids = guid_to_ids(guid) if guid else {}
+            if not ids:
+                ids = simkl_search_ids(headers, title, is_movie=True, year=year)
+                if ids:
+                    logger.debug("IDs encontrados en Simkl para la película '%s': %s", title, ids)
+            if ids:
+                item["ids"] = ids
+            if watched_at:
+                item["watched_at"] = watched_at
+            payload["movies"].append(item)
+
+    if episodes:
+        shows: Dict[str, dict] = {}
+        for show_title, code, guid, watched_at in episodes:
+            ids = guid_to_ids(guid) if guid else {}
+            if not ids:
+                ids = simkl_search_ids(headers, show_title, is_movie=False)
+                if ids:
+                    logger.debug("IDs encontrados en Simkl para la serie '%s': %s", show_title, ids)
+            if not ids:
+                logger.warning("Omitiendo episodio '%s - %s' (sin IDs encontrados)", show_title, code)
+                continue
+            key = tuple(sorted(ids.items()))
+            if key not in shows:
+                shows[key] = {"title": show_title, "ids": ids, "seasons": []}
+            try:
+                season_num, episode_num = map(int, code.upper().lstrip("S").split("E"))
+            except ValueError:
+                logger.warning("Formato de episodio inválido: %s", code)
+                continue
+            season_found = False
+            for s in shows[key]["seasons"]:
+                if s["number"] == season_num:
+                    s["episodes"].append({"number": episode_num, "watched_at": watched_at})
+                    season_found = True
+                    break
+            if not season_found:
+                shows[key]["seasons"].append({"number": season_num, "episodes": [{"number": episode_num, "watched_at": watched_at}]})
+        if shows:
+            payload["shows"] = list(shows.values())
+
+    if not payload:
+        logger.info("No hay ítems nuevos para sincronizar con Simkl")
+        return
+
+    logger.info("Añadiendo %d películas y %d series al historial de Simkl", len(payload.get("movies", [])), len(payload.get("shows", [])))
+    try:
+        simkl_request("post", "/sync/history", headers, json=payload)
+        logger.info("Historial de Simkl actualizado correctamente.")
+    except requests.exceptions.RequestException as e:
+        logger.error("Falló la actualización de Simkl: %s", e)

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -1,0 +1,642 @@
+import json
+import logging
+import os
+import time
+from typing import Dict, List, Optional, Tuple
+
+import requests
+
+from .utils import guid_to_ids, normalize_year, to_iso_z, valid_guid, best_guid, imdb_guid, get_show_from_library, ensure_collection
+
+logger = logging.getLogger(__name__)
+
+TOKEN_FILE = "trakt_tokens.json"
+
+
+def load_trakt_tokens() -> None:
+    if os.environ.get("TRAKT_ACCESS_TOKEN") and os.environ.get("TRAKT_REFRESH_TOKEN"):
+        return
+    if os.path.exists(TOKEN_FILE):
+        try:
+            with open(TOKEN_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            os.environ["TRAKT_ACCESS_TOKEN"] = data.get("access_token", "")
+            os.environ["TRAKT_REFRESH_TOKEN"] = data.get("refresh_token", "")
+            logger.info("Loaded Trakt tokens from %s", TOKEN_FILE)
+        except Exception as exc:
+            logger.error("Failed to load Trakt tokens: %s", exc)
+
+
+def save_trakt_tokens(access_token: str, refresh_token: Optional[str]) -> None:
+    try:
+        with open(TOKEN_FILE, "w", encoding="utf-8") as f:
+            json.dump({"access_token": access_token, "refresh_token": refresh_token}, f, indent=2)
+        logger.info("Saved Trakt tokens to %s", TOKEN_FILE)
+    except Exception as exc:
+        logger.error("Failed to save Trakt tokens: %s", exc)
+
+
+def exchange_code_for_tokens(code: str, redirect_uri: str) -> Optional[dict]:
+    client_id = os.environ.get("TRAKT_CLIENT_ID")
+    client_secret = os.environ.get("TRAKT_CLIENT_SECRET")
+    if not all([code, client_id, client_secret]):
+        logger.error("Missing code or Trakt client credentials.")
+        return None
+
+    payload = {
+        "code": code,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+        "grant_type": "authorization_code",
+    }
+    try:
+        resp = requests.post("https://api.trakt.tv/oauth/token", json=payload, timeout=30)
+        resp.raise_for_status()
+    except Exception as exc:
+        logger.error("Failed to obtain Trakt tokens: %s", exc)
+        return None
+
+    data = resp.json()
+    os.environ["TRAKT_ACCESS_TOKEN"] = data["access_token"]
+    os.environ["TRAKT_REFRESH_TOKEN"] = data.get("refresh_token")
+    save_trakt_tokens(data["access_token"], data.get("refresh_token"))
+    logger.info("Trakt tokens obtained via authorization code")
+    return data
+
+
+def refresh_trakt_token(redirect_uri: str) -> Optional[str]:
+    refresh_token = os.environ.get("TRAKT_REFRESH_TOKEN")
+    client_id = os.environ.get("TRAKT_CLIENT_ID")
+    client_secret = os.environ.get("TRAKT_CLIENT_SECRET")
+    if not all([refresh_token, client_id, client_secret]):
+        logger.error("Missing Trakt OAuth environment variables.")
+        return None
+
+    payload = {
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+        "grant_type": "refresh_token",
+    }
+    try:
+        resp = requests.post("https://api.trakt.tv/oauth/token", json=payload, timeout=30)
+        resp.raise_for_status()
+    except Exception as exc:
+        logger.error("Failed to refresh Trakt token: %s", exc)
+        return None
+
+    data = resp.json()
+    os.environ["TRAKT_ACCESS_TOKEN"] = data["access_token"]
+    os.environ["TRAKT_REFRESH_TOKEN"] = data.get("refresh_token", refresh_token)
+    save_trakt_tokens(data["access_token"], os.environ["TRAKT_REFRESH_TOKEN"])
+    logger.info("Trakt access token refreshed")
+    return data["access_token"]
+
+
+def trakt_request(method: str, endpoint: str, headers: dict, **kwargs) -> requests.Response:
+    url = f"https://api.trakt.tv{endpoint}"
+    resp = requests.request(method, url, headers=headers, timeout=30, **kwargs)
+    if resp.status_code == 401:
+        new_token = refresh_trakt_token(headers.get("redirect_uri", ""))
+        if new_token:
+            headers["Authorization"] = f"Bearer {new_token}"
+            resp = requests.request(method, url, headers=headers, timeout=30, **kwargs)
+
+    if resp.status_code == 420:
+        msg = (
+            "Trakt API returned 420 – account limit exceeded. "
+            "Upgrade to VIP or reduce the size of your collection/watchlist."
+        )
+        logger.warning(msg)
+        raise Exception(msg)
+
+    if resp.status_code == 429:
+        retry_after = int(resp.headers.get("Retry-After", "1"))
+        logger.warning("Trakt API rate limit reached. Retrying in %s seconds", retry_after)
+        time.sleep(retry_after)
+        resp = requests.request(method, url, headers=headers, timeout=30, **kwargs)
+
+    resp.raise_for_status()
+    return resp
+
+
+def get_trakt_history(headers: dict) -> Tuple[
+    Dict[str, Tuple[str, Optional[int], Optional[str]]],
+    Dict[str, Tuple[str, str, Optional[str]]],
+]:
+    movies: Dict[str, Tuple[str, Optional[int], Optional[str]]] = {}
+    episodes: Dict[str, Tuple[str, str, Optional[str]]] = {}
+
+    page = 1
+    logger.info("Fetching Trakt history…")
+    while True:
+        resp = trakt_request("GET", "/sync/history", headers, params={"page": page, "limit": 100})
+        data = resp.json()
+        if not isinstance(data, list) or not data:
+            break
+        for item in data:
+            watched_at = item.get("watched_at")
+            if item["type"] == "movie":
+                m = item["movie"]
+                ids = m.get("ids", {})
+                guid = None
+                if ids.get("imdb"):
+                    guid = f"imdb://{ids['imdb']}"
+                elif ids.get("tmdb"):
+                    guid = f"tmdb://{ids['tmdb']}"
+                if guid and guid not in movies:
+                    movies[guid] = (m["title"], normalize_year(m.get("year")), watched_at)
+            elif item["type"] == "episode":
+                e = item["episode"]
+                show = item["show"]
+                ids = e.get("ids", {})
+                guid = None
+                if ids.get("imdb"):
+                    guid = f"imdb://{ids['imdb']}"
+                elif ids.get("tmdb"):
+                    guid = f"tmdb://{ids['tmdb']}"
+                if guid and guid not in episodes:
+                    episodes[guid] = (show["title"], f"S{e['season']:02d}E{e['number']:02d}", watched_at)
+        page += 1
+
+    return movies, episodes
+
+
+def update_trakt(headers: dict, movies: List[Tuple[str, Optional[int], Optional[str], Optional[str]]], episodes: List[Tuple[str, str, Optional[str], Optional[str]]]) -> None:
+    payload = {"movies": [], "episodes": []}
+
+    for title, year, watched_at, guid in movies:
+        if not valid_guid(guid):
+            continue
+        movie_obj = {"title": title}
+        if year is not None:
+            movie_obj["year"] = year
+        movie_ids = guid_to_ids(guid)
+        if movie_ids:
+            movie_obj["ids"] = movie_ids
+        if watched_at:
+            movie_obj["watched_at"] = watched_at
+        payload["movies"].append(movie_obj)
+
+    for show, code, watched_at, guid in episodes:
+        if not valid_guid(guid):
+            continue
+        season = int(code[1:3])
+        number = int(code[4:6])
+        ep_obj = {"season": season, "number": number}
+        ep_ids = guid_to_ids(guid)
+        if ep_ids:
+            ep_obj["ids"] = ep_ids
+        if watched_at:
+            ep_obj["watched_at"] = watched_at
+        payload["episodes"].append(ep_obj)
+
+    if not payload["movies"] and not payload["episodes"]:
+        logger.info("Nothing new to send to Trakt.")
+        return
+
+    trakt_request("POST", "/sync/history", headers, json=payload)
+    logger.info("Sent %d movies and %d episodes to Trakt", len(payload["movies"]), len(payload["episodes"]))
+
+
+def sync_collection(plex, headers):
+    movies = []
+    for section in plex.library.sections():
+        if section.type == "movie":
+            for item in section.all():
+                guid = best_guid(item)
+                obj = {"title": item.title}
+                if getattr(item, "year", None):
+                    obj["year"] = normalize_year(item.year)
+                if guid:
+                    obj["ids"] = guid_to_ids(guid)
+                movies.append(obj)
+    if movies:
+        trakt_request("POST", "/sync/collection", headers, json={"movies": movies})
+        logger.info("Synced %d Plex movies to Trakt collection", len(movies))
+
+
+def sync_ratings(plex, headers):
+    movies: List[dict] = []
+    shows: List[dict] = []
+    episodes: List[dict] = []
+
+    rated_now = to_iso_z(datetime.utcnow())
+
+    for section in plex.library.sections():
+        if section.type == "movie":
+            for item in section.all():
+                rating = getattr(item, "userRating", None)
+                if rating is not None:
+                    guid = best_guid(item)
+                    obj = {
+                        "title": item.title,
+                        "rating": int(round(float(rating))),
+                        "rated_at": rated_now,
+                    }
+                    if getattr(item, "year", None):
+                        obj["year"] = normalize_year(item.year)
+                    if guid:
+                        obj["ids"] = guid_to_ids(guid)
+                    movies.append(obj)
+        elif section.type == "show":
+            for show in section.all():
+                show_guid = best_guid(show)
+                show_ids = guid_to_ids(show_guid) if show_guid else {}
+                base = {"title": show.title}
+                if getattr(show, "year", None):
+                    base["year"] = normalize_year(show.year)
+                if show_ids:
+                    base["ids"] = show_ids
+
+                seasons_list = []
+                has_show_data = False
+
+                show_rating = getattr(show, "userRating", None)
+                if show_rating is not None:
+                    base["rating"] = int(round(float(show_rating)))
+                    base["rated_at"] = rated_now
+                    has_show_data = True
+
+                for season in show.seasons():
+                    season_rating = getattr(season, "userRating", None)
+                    if season_rating is not None:
+                        seasons_list.append({"number": int(season.index), "rating": int(round(float(season_rating))), "rated_at": rated_now})
+                        has_show_data = True
+                    for ep in season.episodes():
+                        ep_rating = getattr(ep, "userRating", None)
+                        if ep_rating is not None:
+                            ep_obj = {"season": int(season.index), "number": int(ep.index), "rating": int(round(float(ep_rating))), "rated_at": rated_now}
+                            ep_guid = best_guid(ep)
+                            if ep_guid:
+                                ep_obj["ids"] = guid_to_ids(ep_guid)
+                            elif show_ids:
+                                ep_obj["show"] = {"ids": show_ids}
+                            else:
+                                ep_obj["title"] = show.title
+                            episodes.append(ep_obj)
+
+                if seasons_list:
+                    base["seasons"] = seasons_list
+
+                if has_show_data:
+                    shows.append(base)
+
+    payload = {}
+    if movies:
+        payload["movies"] = movies
+    if shows:
+        payload["shows"] = shows
+    if episodes:
+        payload["episodes"] = episodes
+
+    if payload:
+        trakt_request("POST", "/sync/ratings", headers, json=payload)
+        logger.info(
+            "Synced %d movie ratings, %d shows and %d episode ratings to Trakt",
+            len(movies),
+            len(shows),
+            len(episodes),
+        )
+    else:
+        logger.info("No Plex ratings to sync")
+
+
+def sync_liked_lists(plex, headers):
+    try:
+        likes = trakt_request("GET", "/users/likes/lists", headers).json()
+    except Exception as exc:
+        logger.error("Failed to fetch liked lists: %s", exc)
+        return
+    for like in likes:
+        lst = like.get("list", {})
+        owner = lst.get("user", {}).get("ids", {}).get("slug") or lst.get("user", {}).get("username")
+        slug = lst.get("ids", {}).get("slug")
+        name = lst.get("name", slug)
+        if not owner or not slug:
+            continue
+        try:
+            items = trakt_request("GET", f"/users/{owner}/lists/{slug}/items", headers).json()
+        except Exception as exc:
+            logger.error("Failed to fetch list %s/%s: %s", owner, slug, exc)
+            continue
+        movie_items = []
+        show_items = []
+        for it in items:
+            data = it.get(it["type"], {})
+            ids = data.get("ids", {})
+            guid = None
+            if ids.get("imdb"):
+                guid = f"imdb://{ids['imdb']}"
+            elif ids.get("tmdb"):
+                guid = f"tmdb://{ids['tmdb']}"
+            elif ids.get("tvdb"):
+                guid = f"tvdb://{ids['tvdb']}"
+            if not guid:
+                continue
+            plex_item = find_item_by_guid(plex, guid)
+            if plex_item:
+                if plex_item.TYPE == "movie":
+                    movie_items.append(plex_item)
+                elif plex_item.TYPE == "show":
+                    show_items.append(plex_item)
+        if movie_items or show_items:
+            for sec in plex.library.sections():
+                if sec.type == "movie" and movie_items:
+                    coll = ensure_collection(plex, sec, name, first_item=movie_items[0])
+                    try:
+                        if len(movie_items) > 1:
+                            coll.addItems(movie_items[1:])
+                    except Exception:
+                        pass
+                if sec.type == "show" and show_items:
+                    coll = ensure_collection(plex, sec, name, first_item=show_items[0])
+                    try:
+                        if len(show_items) > 1:
+                            coll.addItems(show_items[1:])
+                    except Exception:
+                        pass
+
+
+def sync_collections_to_trakt(plex, headers):
+    try:
+        user_data = trakt_request("GET", "/users/settings", headers).json()
+        username = user_data.get("user", {}).get("ids", {}).get("slug") or user_data.get("user", {}).get("username")
+        lists = trakt_request("GET", f"/users/{username}/lists", headers).json()
+    except Exception as exc:
+        logger.error("Failed to fetch Trakt lists: %s", exc)
+        return
+
+    slug_by_name = {l.get("name"): l.get("ids", {}).get("slug") for l in lists}
+
+    for sec in plex.library.sections():
+        if sec.type not in ("movie", "show"):
+            continue
+        for coll in sec.collections():
+            slug = slug_by_name.get(coll.title)
+            if not slug:
+                try:
+                    resp = trakt_request("POST", f"/users/{username}/lists", headers, json={"name": coll.title})
+                    slug = resp.json().get("ids", {}).get("slug")
+                    slug_by_name[coll.title] = slug
+                except Exception as exc:
+                    logger.error("Failed creating list %s: %s", coll.title, exc)
+                    continue
+            try:
+                items = trakt_request("GET", f"/users/{username}/lists/{slug}/items", headers).json()
+            except Exception as exc:
+                logger.error("Failed to fetch list %s items: %s", slug, exc)
+                continue
+            trakt_guids = set()
+            for it in items:
+                data = it.get(it["type"], {})
+                ids = data.get("ids", {})
+                if ids.get("imdb"):
+                    trakt_guids.add(f"imdb://{ids['imdb']}")
+                elif ids.get("tmdb"):
+                    trakt_guids.add(f"tmdb://{ids['tmdb']}")
+                elif ids.get("tvdb"):
+                    trakt_guids.add(f"tvdb://{ids['tvdb']}")
+            movies = []
+            shows = []
+            for item in coll.items():
+                guid = imdb_guid(item)
+                if not guid or guid in trakt_guids:
+                    continue
+                if item.type == "movie":
+                    movies.append({"ids": guid_to_ids(guid)})
+                elif item.type == "show":
+                    shows.append({"ids": guid_to_ids(guid)})
+            payload = {}
+            if movies:
+                payload["movies"] = movies
+            if shows:
+                payload["shows"] = shows
+            if payload:
+                try:
+                    trakt_request("POST", f"/users/{username}/lists/{slug}/items", headers, json=payload)
+                    logger.info("Updated Trakt list %s with %d items", slug, len(movies) + len(shows))
+                except Exception as exc:
+                    logger.error("Failed updating list %s: %s", slug, exc)
+
+
+def sync_watchlist(plex, headers, plex_history, trakt_history):
+    account = plex.myPlexAccount()
+    try:
+        plex_watch = account.watchlist()
+    except Exception as exc:
+        logger.error("Failed to fetch Plex watchlist: %s", exc)
+        plex_watch = []
+    try:
+        trakt_movies = trakt_request("GET", "/sync/watchlist/movies", headers).json()
+        trakt_shows = trakt_request("GET", "/sync/watchlist/shows", headers).json()
+    except Exception as exc:
+        logger.error("Failed to fetch Trakt watchlist: %s", exc)
+        return
+
+    plex_guids = set()
+    for item in plex_watch:
+        g = imdb_guid(item)
+        if g:
+            plex_guids.add(g)
+
+    trakt_guids = set()
+    for lst in (trakt_movies, trakt_shows):
+        for it in lst:
+            ids = it.get(it["type"], {}).get("ids", {})
+            if ids.get("imdb"):
+                trakt_guids.add(f"imdb://{ids['imdb']}")
+            elif ids.get("tmdb"):
+                trakt_guids.add(f"tmdb://{ids['tmdb']}")
+            elif ids.get("tvdb"):
+                trakt_guids.add(f"tvdb://{ids['tvdb']}")
+
+    movies_to_add = []
+    shows_to_add = []
+    for item in plex_watch:
+        guid = imdb_guid(item)
+        if not guid or guid in trakt_guids:
+            continue
+        data = guid_to_ids(guid)
+        if item.TYPE == "movie":
+            movies_to_add.append({"ids": data})
+        elif item.TYPE == "show":
+            shows_to_add.append({"ids": data})
+    payload = {}
+    if movies_to_add:
+        payload["movies"] = movies_to_add
+    if shows_to_add:
+        payload["shows"] = shows_to_add
+    if payload:
+        trakt_request("POST", "/sync/watchlist", headers, json=payload)
+        logger.info("Added %d items to Trakt watchlist", len(movies_to_add) + len(shows_to_add))
+
+    add_to_plex = []
+    for lst in (trakt_movies, trakt_shows):
+        for it in lst:
+            data = it.get(it["type"], {})
+            ids = data.get("ids", {})
+            guid = None
+            if ids.get("imdb"):
+                guid = f"imdb://{ids['imdb']}"
+            elif ids.get("tmdb"):
+                guid = f"tmdb://{ids['tmdb']}"
+            if not guid or guid in plex_guids:
+                continue
+            item = find_item_by_guid(plex, guid)
+            if item:
+                add_to_plex.append(item)
+    if add_to_plex:
+        try:
+            account.addToWatchlist(add_to_plex)
+            logger.info("Added %d items to Plex watchlist", len(add_to_plex))
+        except Exception as exc:
+            logger.error("Failed adding Plex watchlist items: %s", exc)
+
+    for guid in list(plex_guids):
+        if guid in trakt_history or guid in plex_history:
+            try:
+                item = find_item_by_guid(plex, guid)
+                if item:
+                    account.removeFromWatchlist([item])
+            except Exception:
+                pass
+    remove = []
+    for lst in (trakt_movies, trakt_shows):
+        for it in lst:
+            data = it.get(it["type"], {})
+            ids = data.get("ids", {})
+            guid = None
+            if ids.get("imdb"):
+                guid = f"imdb://{ids['imdb']}"
+            elif ids.get("tmdb"):
+                guid = f"tmdb://{ids['tmdb']}"
+            elif ids.get("tvdb"):
+                guid = f"tvdb://{ids['tvdb']}"
+            if guid and (guid in plex_history or guid in trakt_history) and guid not in plex_guids:
+                remove.append({"ids": guid_to_ids(guid)})
+    if remove:
+        trakt_request("POST", "/sync/watchlist/remove", headers, json={"movies": remove, "shows": remove})
+        logger.info("Removed %d items from Trakt watchlist", len(remove))
+
+
+def fetch_trakt_history_full(headers) -> list:
+    all_items = []
+    page = 1
+    while True:
+        resp = trakt_request("GET", "/sync/history", headers, params={"page": page, "limit": 100})
+        data = resp.json()
+        if not data:
+            break
+        all_items.extend(data)
+        page += 1
+    return all_items
+
+
+def fetch_trakt_ratings(headers) -> list:
+    all_items = []
+    page = 1
+    while True:
+        resp = trakt_request("GET", "/sync/ratings", headers, params={"page": page, "limit": 100})
+        data = resp.json()
+        if not data:
+            break
+        all_items.extend(data)
+        page += 1
+    return all_items
+
+
+def fetch_trakt_watchlist(headers) -> dict:
+    movies = trakt_request("GET", "/sync/watchlist/movies", headers).json()
+    shows = trakt_request("GET", "/sync/watchlist/shows", headers).json()
+    return {"movies": movies, "shows": shows}
+
+
+def restore_backup(headers, data: dict) -> None:
+    history = data.get("history", [])
+    movies = []
+    episodes = []
+    for item in history:
+        if item.get("type") == "movie":
+            m = item.get("movie", {})
+            ids = m.get("ids", {})
+            if ids:
+                obj = {"ids": ids}
+                if item.get("watched_at"):
+                    obj["watched_at"] = item["watched_at"]
+                if m.get("title"):
+                    obj["title"] = m.get("title")
+                if m.get("year"):
+                    obj["year"] = m.get("year")
+                movies.append(obj)
+        elif item.get("type") == "episode":
+            ep = item.get("episode", {})
+            ids = ep.get("ids", {})
+            if ids:
+                obj = {"ids": ids, "season": ep.get("season"), "number": ep.get("number")}
+                if item.get("watched_at"):
+                    obj["watched_at"] = item["watched_at"]
+                show = item.get("show", {})
+                if show.get("ids"):
+                    obj["show"] = {"ids": show.get("ids")}
+                episodes.append(obj)
+    payload = {}
+    if movies:
+        payload["movies"] = movies
+    if episodes:
+        payload["episodes"] = episodes
+    if payload:
+        trakt_request("POST", "/sync/history", headers, json=payload)
+
+    ratings = data.get("ratings", [])
+    r_movies, r_shows, r_episodes, r_seasons = [], [], [], []
+    for item in ratings:
+        typ = item.get("type")
+        ids = item.get(typ, {}).get("ids", {}) if typ else {}
+        if not ids:
+            continue
+        obj = {"ids": ids, "rating": item.get("rating")}
+        if item.get("rated_at"):
+            obj["rated_at"] = item["rated_at"]
+        if typ == "movie":
+            r_movies.append(obj)
+        elif typ == "show":
+            r_shows.append(obj)
+        elif typ == "season":
+            r_seasons.append(obj)
+        elif typ == "episode":
+            r_episodes.append(obj)
+    payload = {}
+    if r_movies:
+        payload["movies"] = r_movies
+    if r_shows:
+        payload["shows"] = r_shows
+    if r_seasons:
+        payload["seasons"] = r_seasons
+    if r_episodes:
+        payload["episodes"] = r_episodes
+    if payload:
+        trakt_request("POST", "/sync/ratings", headers, json=payload)
+
+    watchlist = data.get("watchlist", {})
+    wl_movies = []
+    for it in watchlist.get("movies", []):
+        m = it.get("movie", {})
+        ids = m.get("ids", {})
+        if ids:
+            wl_movies.append({"ids": ids})
+    wl_shows = []
+    for it in watchlist.get("shows", []):
+        s = it.get("show", {}) if "show" in it else it.get("movie", {})
+        ids = s.get("ids", {})
+        if ids:
+            wl_shows.append({"ids": ids})
+    payload = {}
+    if wl_movies:
+        payload["movies"] = wl_movies
+    if wl_shows:
+        payload["shows"] = wl_shows
+    if payload:
+        trakt_request("POST", "/sync/watchlist", headers, json=payload)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,248 @@
+import logging
+from datetime import datetime, timezone
+from numbers import Number
+from typing import Dict, Optional, Tuple, Union
+from plexapi.exceptions import NotFound
+
+logger = logging.getLogger(__name__)
+
+
+def to_iso_z(value) -> Optional[str]:
+    """Convert any ``viewedAt`` variant to ISO-8601 UTC ("...Z")."""
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    if isinstance(value, Number):
+        return datetime.utcfromtimestamp(value).isoformat() + "Z"
+
+    if isinstance(value, str):
+        try:
+            return datetime.utcfromtimestamp(int(value)).isoformat() + "Z"
+        except (TypeError, ValueError):
+            pass
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        except ValueError:
+            pass
+
+    logger.warning("Unrecognized viewedAt format: %r (%s)", value, type(value))
+    return None
+
+
+def normalize_year(value: Union[str, int, None]) -> Optional[int]:
+    """Return ``value`` as ``int`` if possible, otherwise ``None``."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.debug("Invalid year value: %r", value)
+        return None
+
+
+def _parse_guid_value(raw: str) -> Optional[str]:
+    """Convert a raw Plex GUID string to a known imdb/tmdb/tvdb/anidb prefix."""
+    if raw.startswith("imdb://"):
+        return raw.split("?", 1)[0]
+    if raw.startswith("tmdb://"):
+        return raw.split("?", 1)[0]
+    if raw.startswith("tvdb://"):
+        return raw.split("?", 1)[0]
+    if raw.startswith("anidb://"):
+        return raw.split("?", 1)[0]
+    if "themoviedb://" in raw:
+        val = raw.split("themoviedb://", 1)[1].split("?", 1)[0]
+        return f"tmdb://{val.split('/')[0]}"
+    if "thetvdb://" in raw:
+        val = raw.split("thetvdb://", 1)[1].split("?", 1)[0]
+        return f"tvdb://{val.split('/')[0]}"
+    if "imdb://" in raw:
+        val = raw.split("imdb://", 1)[1].split("?", 1)[0]
+        return f"imdb://{val.split('/')[0]}"
+    return None
+
+
+def best_guid(item) -> Optional[str]:
+    """Return a preferred GUID (imdb → tmdb → tvdb) for a Plex item."""
+    try:
+        for g in getattr(item, "guids", []) or []:
+            val = _parse_guid_value(g.id)
+            if val and val.startswith("imdb://"):
+                return val
+        for g in getattr(item, "guids", []) or []:
+            val = _parse_guid_value(g.id)
+            if val and (val.startswith("tmdb://") or val.startswith("tvdb://")):
+                return val
+        if getattr(item, "guid", None):
+            return _parse_guid_value(item.guid)
+    except Exception as exc:
+        logger.debug("Failed retrieving GUIDs: %s", exc)
+    return None
+
+
+def imdb_guid(item) -> Optional[str]:
+    """Return an IMDb, TMDb, TVDb or AniDB GUID for a Plex item."""
+    try:
+        for g in getattr(item, "guids", []) or []:
+            val = _parse_guid_value(g.id)
+            if val and val.startswith("imdb://"):
+                return val
+        for g in getattr(item, "guids", []) or []:
+            val = _parse_guid_value(g.id)
+            if val and val.startswith("tmdb://"):
+                return val
+        for g in getattr(item, "guids", []) or []:
+            val = _parse_guid_value(g.id)
+            if val and val.startswith("tvdb://"):
+                return val
+        for g in getattr(item, "guids", []) or []:
+            val = _parse_guid_value(g.id)
+            if val and val.startswith("anidb://"):
+                return val
+        if getattr(item, "guid", None):
+            val = _parse_guid_value(item.guid)
+            if val and val.startswith("imdb://"):
+                return val
+            if val and val.startswith("tmdb://"):
+                return val
+            if val and val.startswith("tvdb://"):
+                return val
+            if val and val.startswith("anidb://"):
+                return val
+    except Exception as exc:
+        logger.debug("Failed retrieving IMDb GUID: %s", exc)
+    return None
+
+
+def get_show_from_library(plex, title):
+    """Return a show object from any library section."""
+    for sec in plex.library.sections():
+        if sec.type == "show":
+            try:
+                return sec.get(title)
+            except NotFound:
+                try:
+                    results = sec.search(title=title)
+                    if results:
+                        return results[0]
+                except Exception:
+                    pass
+                continue
+    return None
+
+
+def find_item_by_guid(plex, guid):
+    """Return a movie or show from Plex matching the given GUID."""
+    for sec in plex.library.sections():
+        if sec.type in ("movie", "show"):
+            try:
+                return sec.getGuid(guid)
+            except Exception:
+                continue
+    return None
+
+
+def ensure_collection(plex, section, name, first_item=None):
+    """Return a Plex collection with ``name`` creating it if needed."""
+    try:
+        return section.collection(name)
+    except Exception:
+        if first_item is None:
+            raise
+        return plex.createCollection(name, section, items=[first_item])
+
+
+def movie_key(title: str, year: Optional[int], guid: Optional[str]) -> Union[str, Tuple[str, Optional[int]]]:
+    """Return a unique key for comparing movies."""
+    if guid:
+        return guid
+    return (title, year)
+
+
+def guid_to_ids(guid: str) -> Dict[str, Union[str, int]]:
+    """Convert a Plex GUID to a Trakt ids mapping."""
+    if guid.startswith("imdb://"):
+        return {"imdb": guid.split("imdb://", 1)[1]}
+    if guid.startswith("tmdb://"):
+        return {"tmdb": int(guid.split("tmdb://", 1)[1])}
+    if guid.startswith("tvdb://"):
+        return {"tvdb": int(guid.split("tvdb://", 1)[1])}
+    if guid.startswith("anidb://"):
+        return {"anidb": int(guid.split("anidb://", 1)[1])}
+    return {}
+
+
+def valid_guid(guid: Optional[str]) -> bool:
+    """Return True if ``guid`` is a valid IMDb, TMDb, TVDb or AniDB identifier."""
+    return bool(guid) and guid.startswith(("imdb://", "tmdb://", "tvdb://", "anidb://"))
+
+
+def trakt_movie_key(m: dict) -> Union[str, Tuple[str, Optional[int]]]:
+    """Return a unique key for a Trakt movie object."""
+    ids = m.get("ids", {})
+    if ids.get("imdb"):
+        return f"imdb://{ids['imdb']}"
+    if ids.get("tmdb"):
+        return f"tmdb://{ids['tmdb']}"
+    if ids.get("tvdb"):
+        return f"tvdb://{ids['tvdb']}"
+    if ids.get("anidb"):
+        return f"anidb://{ids['anidb']}"
+    return m["title"].lower()
+
+
+def episode_key(show: str, code: str, guid: Optional[str]) -> Union[str, Tuple[str, str]]:
+    if guid and guid.startswith(("imdb://", "tmdb://", "tvdb://", "anidb://")):
+        return guid
+    return (show.lower(), code)
+
+
+def trakt_episode_key(show: dict, e: dict) -> Union[str, Tuple[str, str]]:
+    ids = e.get("ids", {})
+    if ids.get("imdb"):
+        return f"imdb://{ids['imdb']}"
+    if ids.get("tmdb"):
+        return f"tmdb://{ids['tmdb']}"
+    if ids.get("tvdb"):
+        return f"tvdb://{ids['tvdb']}"
+    if ids.get("anidb"):
+        return f"anidb://{ids['anidb']}"
+    return (show["title"].lower(), f"S{e['season']:02d}E{e['number']:02d}")
+
+
+def simkl_episode_key(show: dict, e: dict) -> Optional[Union[str, Tuple[str, str]]]:
+    """Return best key for a Simkl episode object."""
+    ids = e.get("ids", {}) or {}
+    if ids.get("imdb"):
+        return f"imdb://{ids['imdb']}"
+    if ids.get("tmdb"):
+        return f"tmdb://{ids['tmdb']}"
+    if ids.get("tvdb"):
+        return f"tvdb://{ids['tvdb']}"
+    if ids.get("anidb"):
+        return f"anidb://{ids['anidb']}"
+
+    show_ids = show.get("ids", {}) or {}
+    base_guid: Optional[str] = None
+    if show_ids.get("imdb"):
+        base_guid = f"imdb://{show_ids['imdb']}"
+    elif show_ids.get("tmdb"):
+        base_guid = f"tmdb://{show_ids['tmdb']}"
+    elif show_ids.get("tvdb"):
+        base_guid = f"tvdb://{show_ids['tvdb']}"
+    elif show_ids.get("anidb"):
+        base_guid = f"anidb://{show_ids['anidb']}"
+
+    season_num = e.get("season", 0)
+    episode_num = e.get("number", 0)
+    code = f"S{season_num:02d}E{episode_num:02d}"
+
+    if base_guid:
+        return (base_guid, code)
+    return (show.get("title", "").lower(), code)


### PR DESCRIPTION
## Summary
- organize provider functions into their own modules
- expose helpers in `utils.py`
- update `app.py` to use the new modules

## Testing
- `python -m py_compile app.py plex_utils.py trakt_utils.py simkl_utils.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f0b2eaf0832eb36dc33f712886ba