### PR TITLE
Add reverse proxy OAuth note

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you want to remove saved tokens, the Config page also provides **Clear Config
 When specifying a custom redirect URI for either service, ensure the same
 value is configured in your Trakt or Simkl application and passed via the
 `TRAKT_REDIRECT_URI` or `SIMKL_REDIRECT_URI` environment variables.
+If PlexyTrack is accessed through a reverse proxy, add both `https` and `http` versions of the OAuth redirect URL to avoid failures. For example, use `https://example.com/oauth/trakt` and `http://example.com/oauth/trakt` and set the same when creating the Simkl application.
 
 The application uses `plexapi` version 4.15 or newer (but below 5).
 


### PR DESCRIPTION
## Summary
- add clarification on OAuth URLs when using PlexyTrack behind a reverse proxy

## Testing
- `python3 -m py_compile app.py plex_utils.py simkl_utils.py trakt_utils.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684b263212d0832e846265aaf79aaf7b