### PR TITLE
Fix sync error when processing Trakt history

### DIFF
--- a/app.py
+++ b/app.py
@@ -1485,12 +1485,12 @@ def sync():
 
             missing_movies = {
                 (title, year, guid)
-                for guid, (title, year) in trakt_movies.items()
+                for guid, (title, year, *_rest) in trakt_movies.items()
                 if guid not in plex_movie_guids
             }
             missing_episodes = {
                 (show, code, guid)
-                for guid, (show, code) in trakt_episodes.items()
+                for guid, (show, code, *_rest) in trakt_episodes.items()
                 if guid not in plex_episode_guids
             }
             try:


### PR DESCRIPTION
## Summary
- handle `watched_at` tuple element when computing missing movies and episodes

## Testing
- `python -m py_compile app.py plex_utils.py trakt_utils.py simkl_utils.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684c02febee4832e812c85f6c0a22819