### PR TITLE
Unify license footer

### DIFF
--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -49,7 +49,7 @@
         </main>
 
         <footer class="app-footer">
-            <p>&copy; 2025 PlexyTrack. All rights reserved.</p>
+            <p>MIT License. By <a href="https://github.com/Drakonis96" target="_blank" rel="noopener">Drakonis96</a></p>
         </footer>
     </div>
 </body>

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -52,7 +52,7 @@
         </main>
 
         <footer class="app-footer">
-            <p>MIT License. by <a href="https://github.com/Drakonis96" target="_blank" rel="noopener">Drakonis96</a></p>
+            <p>MIT License. By <a href="https://github.com/Drakonis96" target="_blank" rel="noopener">Drakonis96</a></p>
         </footer>
     </div>
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -74,7 +74,7 @@
         </main>
 
         <footer class="app-footer">
-            <p>MIT License. by Drakonis96</p>
+            <p>MIT License. By <a href="https://github.com/Drakonis96" target="_blank" rel="noopener">Drakonis96</a></p>
         </footer>
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,7 +84,7 @@
         </main>
 
         <footer class="app-footer">
-            <p>MIT License. by Drakonis96</p>
+            <p>MIT License. By <a href="https://github.com/Drakonis96" target="_blank" rel="noopener">Drakonis96</a></p>
         </footer>
     </div>
 

--- a/templates/oauth.html
+++ b/templates/oauth.html
@@ -39,7 +39,7 @@
         </main>
 
         <footer class="app-footer">
-            <p>MIT License. by Drakonis96</p>
+            <p>MIT License. By <a href="https://github.com/Drakonis96" target="_blank" rel="noopener">Drakonis96</a></p>
         </footer>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- unify the footer text across all templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c6ddf3940832e9a3b3e4f04091805