### PR TITLE
Fix Simkl OAuth text and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ the application will trigger an immediate sync whenever an event is received.
 3. After saving the app you will see a **Client ID** and **Client Secret**. Keep them handy.
 4. Start PlexyTrack and open `http://localhost:5030` in your browser. From the **Config.** tab you can authorize PlexyTrack on Trakt. After authorizing, Trakt will redirect you to the **OAuth** tab where the code will appear automatically.
 
+## Getting Simkl API credentials
+
+1. Sign in to your Simkl account and visit <https://simkl.com/apps>.
+2. Click **Create new app**, provide any name and set the redirect URL to match `http://localhost:5030/oauth/simkl` or your `SIMKL_REDIRECT_URI`.
+3. After saving the app you will see a **Client ID** and **Client Secret**. Keep them handy.
+4. Open PlexyTrack and from the **Config.** tab choose **Configure** under Simkl to authorize the app.
+
 
 ## Running with Docker Compose
 

--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -27,7 +27,7 @@
                 <p class="description">To continue, please authorize PlexyTrack to access your {{ service }} account.</p>
                 
                 <div class="auth-steps">
-                    <p>1. Click the link below to go to the Trakt authorization page:</p>
+                    <p>1. Click the link below to go to the {{ service }} authorization page:</p>
                     <a href="{{ auth_url }}" target="_blank" class="button primary auth-link">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M10 6V8H5V19H16V14H18V20C18 20.5523 17.5523 21 17 21H4C3.44772 21 3 20.5523 3 20V7C3 6.44772 3.44772 6 4 6H10ZM12 3H19C19.5523 3 20 3.44772 20 4V11C20 11.5523 19.5523 12 19 12H12C11.4477 12 11 11.5523 11 11V4C11 3.44772 11.4477 3 12 3ZM13 5V10H18V5H13Z"></path></svg>
                         {{ service }} authorization


### PR DESCRIPTION
## Summary
- fix authorization page text for Simkl
- document how to obtain Simkl API credentials

## Testing
- `python3 -m py_compile app.py plex_utils.py simkl_utils.py trakt_utils.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684caa27e950832e8cc7c88ae05b1c29