### PR TITLE
Remove invalid Simkl pagination parameters

### DIFF
--- a/app.py
+++ b/app.py
@@ -807,22 +807,18 @@ def get_simkl_history(
     episodes: Dict[str, Tuple[str, str, Optional[str]]] = {}
     
     # First, get movies from sync/history (watched history)
-    params = {"limit": 100, "type": "movies"}
+    params = {"type": "movies"}
     if date_from:
         params["date_from"] = date_from
-    page = 1
     logger.info("Fetching Simkl watch history…")
-    while True:
-        params["page"] = page
-        resp = simkl_request(
-            "GET",
-            "/sync/history",
-            headers,
-            params=params,
-        )
-        data = resp.json()
-        if not isinstance(data, list) or not data:
-            break
+    resp = simkl_request(
+        "GET",
+        "/sync/history",
+        headers,
+        params=params,
+    )
+    data = resp.json()
+    if isinstance(data, list):
         for item in data:
             m = item.get("movie", {})
             guid = simkl_movie_key(m)
@@ -834,25 +830,20 @@ def get_simkl_history(
                     normalize_year(m.get("year")),
                     item.get("watched_at"),
                 )
-        page += 1
     
     # Get episodes from sync/history
-    params = {"limit": 100, "type": "episodes"}
+    params = {"type": "episodes"}
     if date_from:
         params["date_from"] = date_from
-    page = 1
     logger.info("Fetching Simkl episode history…")
-    while True:
-        params["page"] = page
-        resp = simkl_request(
-            "GET",
-            "/sync/history",
-            headers,
-            params=params,
-        )
-        data = resp.json()
-        if not isinstance(data, list) or not data:
-            break
+    resp = simkl_request(
+        "GET",
+        "/sync/history",
+        headers,
+        params=params,
+    )
+    data = resp.json()
+    if isinstance(data, list):
         for item in data:
             e = item.get("episode", {})
             show = item.get("show", {})
@@ -865,7 +856,6 @@ def get_simkl_history(
                     f"S{e.get('season', 0):02d}E{e.get('number', 0):02d}",
                     item.get("watched_at"),
                 )
-        page += 1
     
     # Then, get movies from sync/all-items to include completed movies
     logger.info("Fetching Simkl all-items (full)…")
@@ -2136,7 +2126,7 @@ def test_connections() -> bool:
             "simkl-api-key": simkl_client_id,
         }
         try:
-            simkl_request("GET", "/sync/history", headers, params={"limit": 1})
+            simkl_request("GET", "/sync/history", headers)
             logger.info("Successfully connected to Simkl.")
         except Exception as exc:
             logger.error("Failed to connect to Simkl: %s", exc)

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -171,17 +171,13 @@ def get_simkl_history(
     movies: Dict[str, Tuple[str, Optional[int], Optional[str]]] = {}
     episodes: Dict[str, Tuple[str, str, Optional[str]]] = {}
 
-    params = {"limit": 100, "type": "movies"}
+    params = {"type": "movies"}
     if date_from:
         params["date_from"] = date_from
-    page = 1
     logger.info("Fetching Simkl watch history…")
-    while True:
-        params["page"] = page
-        resp = simkl_request("GET", "/sync/history", headers, params=params)
-        data = resp.json()
-        if not isinstance(data, list) or not data:
-            break
+    resp = simkl_request("GET", "/sync/history", headers, params=params)
+    data = resp.json()
+    if isinstance(data, list):
         for item in data:
             m = item.get("movie", {})
             guid = simkl_movie_key(m)
@@ -189,19 +185,14 @@ def get_simkl_history(
                 continue
             if guid not in movies:
                 movies[guid] = (m.get("title"), normalize_year(m.get("year")), item.get("watched_at"))
-        page += 1
 
-    params = {"limit": 100, "type": "episodes"}
+    params = {"type": "episodes"}
     if date_from:
         params["date_from"] = date_from
-    page = 1
     logger.info("Fetching Simkl episode history…")
-    while True:
-        params["page"] = page
-        resp = simkl_request("GET", "/sync/history", headers, params=params)
-        data = resp.json()
-        if not isinstance(data, list) or not data:
-            break
+    resp = simkl_request("GET", "/sync/history", headers, params=params)
+    data = resp.json()
+    if isinstance(data, list):
         for item in data:
             e = item.get("episode", {})
             show = item.get("show", {})
@@ -210,7 +201,6 @@ def get_simkl_history(
                 continue
             if guid not in episodes:
                 episodes[guid] = (show.get("title"), f"S{e.get('season', 0):02d}E{e.get('number', 0):02d}", item.get("watched_at"))
-        page += 1
 
     return movies, episodes
 


### PR DESCRIPTION
## Summary
- fix `get_simkl_history` so it no longer sends `page`/`limit`
- adjust Simkl connection test accordingly

## Testing
- `python -m py_compile app.py simkl_utils.py trakt_utils.py utils.py plex_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684d20ba9520832e8d1ae5091ced5e4d