### PR TITLE
Fix Plex user sync token handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ from utils import (
     trakt_episode_key,
     simkl_episode_key,
 )
-from plex_utils import get_plex_history, update_plex
+from plex_utils import get_plex_history, update_plex, get_user_token
 from trakt_utils import (
     load_trakt_tokens,
     save_trakt_tokens,
@@ -1517,7 +1517,12 @@ def sync():
                 if guid not in plex_episode_guids
             }
             try:
-                update_plex(plex, missing_movies, missing_episodes)
+                if PLEX_ACCOUNTS:
+                    for acc in PLEX_ACCOUNTS:
+                        token = get_user_token(plex, acc)
+                        update_plex(plex, missing_movies, missing_episodes, token)
+                else:
+                    update_plex(plex, missing_movies, missing_episodes)
             except Exception as exc:
                 logger.error("Failed updating Plex history: %s", exc)
 
@@ -1641,7 +1646,12 @@ def sync():
                 for e in episodes_to_add_plex
             }
             if movies_to_add_plex_fmt or episodes_to_add_plex_fmt:
-                update_plex(plex, movies_to_add_plex_fmt, episodes_to_add_plex_fmt)
+                if PLEX_ACCOUNTS:
+                    for acc in PLEX_ACCOUNTS:
+                        token = get_user_token(plex, acc)
+                        update_plex(plex, movies_to_add_plex_fmt, episodes_to_add_plex_fmt, token)
+                else:
+                    update_plex(plex, movies_to_add_plex_fmt, episodes_to_add_plex_fmt)
 
             if current_activity:
                 save_last_sync_date(current_activity)
@@ -1923,9 +1933,9 @@ def config_page():
             if provider == "none":
                 stop_scheduler()
             return redirect(url_for("config_page"))
-        if "accounts" in request.form:
-            selected = request.form.getlist("accounts")
-            save_plex_accounts(selected)
+        if "account" in request.form:
+            selected = request.form.get("account")
+            save_plex_accounts([selected] if selected else [])
             return redirect(url_for("config_page"))
     trakt_configured = bool(os.environ.get("TRAKT_ACCESS_TOKEN"))
     simkl_configured = bool(os.environ.get("SIMKL_ACCESS_TOKEN"))

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -14,6 +14,20 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 
+def get_user_token(plex, identifier: str) -> Optional[str]:
+    """Return an access token for the given Plex user identifier."""
+    try:
+        account = plex.myPlexAccount()
+        if identifier in (str(account.id), getattr(account, "username", None)):
+            return plex._token
+        for user in account.users():
+            if identifier in (str(user.id), user.title, getattr(user, "username", None)):
+                return user.get_token(plex.machineIdentifier)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to get token for Plex user %s: %s", identifier, exc)
+    return None
+
+
 def get_plex_history(plex, accounts: Optional[List[str]] = None) -> Tuple[
     Dict[str, Dict[str, Optional[str]]],
     Dict[str, Dict[str, Optional[str]]],
@@ -146,6 +160,7 @@ def update_plex(
     plex,
     movies: Set[Tuple[str, Optional[int], Optional[str]]],
     episodes: Set[Tuple[str, str, Optional[str]]],  # Only allow str for key, not Tuple fallback
+    token: Optional[str] = None,
 ) -> None:
     """Mark items as watched in Plex when missing."""
     movie_count = 0
@@ -158,7 +173,11 @@ def update_plex(
                 if item and getattr(item, "isWatched", lambda: bool(getattr(item, "viewCount", 0)))():
                     continue
                 if item:
-                    item.markWatched()
+                    params = {"key": item.ratingKey, "identifier": "com.plexapp.plugins.library"}
+                    if token:
+                        plex.query("/:/scrobble", params=params, headers={"X-Plex-Token": token})
+                    else:
+                        plex.query("/:/scrobble", params=params)
                     movie_count += 1
                     continue
             except Exception as exc:
@@ -188,7 +207,11 @@ def update_plex(
             is_watched = getattr(found, "isWatched", False) or bool(getattr(found, "viewCount", 0))
             if is_watched:
                 continue
-            found.markWatched()
+            params = {"key": found.ratingKey, "identifier": "com.plexapp.plugins.library"}
+            if token:
+                plex.query("/:/scrobble", params=params, headers={"X-Plex-Token": token})
+            else:
+                plex.query("/:/scrobble", params=params)
             movie_count += 1
         except Exception as exc:
             logger.debug("Failed to mark movie '%s' as watched: %s", found.title, exc)
@@ -207,7 +230,11 @@ def update_plex(
                     is_watched = getattr(item, "isWatched", False) or bool(getattr(item, "viewCount", 0))
                     if is_watched:
                         continue
-                    item.markWatched()
+                    params = {"key": item.ratingKey, "identifier": "com.plexapp.plugins.library"}
+                    if token:
+                        plex.query("/:/scrobble", params=params, headers={"X-Plex-Token": token})
+                    else:
+                        plex.query("/:/scrobble", params=params)
                     episode_count += 1
                     continue
             except Exception as exc:
@@ -231,7 +258,11 @@ def update_plex(
             is_watched = getattr(ep_obj, "isWatched", False) or bool(getattr(ep_obj, "viewCount", 0))
             if is_watched:
                 continue
-            ep_obj.markWatched()
+            params = {"key": ep_obj.ratingKey, "identifier": "com.plexapp.plugins.library"}
+            if token:
+                plex.query("/:/scrobble", params=params, headers={"X-Plex-Token": token})
+            else:
+                plex.query("/:/scrobble", params=params)
             episode_count += 1
         except Exception as exc:
             logger.debug("Failed marking episode %s - %s as watched: %s", show_title, code, exc)

--- a/templates/config.html
+++ b/templates/config.html
@@ -77,7 +77,7 @@
                 <form method="post" class="user-form">
                     {% for uid, name in plex_users %}
                     <div class="checkbox-group">
-                        <input type="checkbox" id="user_{{ uid }}" name="accounts" value="{{ uid }}" {% if not selected_users or uid in selected_users %}checked{% endif %}>
+                        <input type="radio" id="user_{{ uid }}" name="account" value="{{ uid }}" {% if uid in selected_users %}checked{% endif %}>
                         <label for="user_{{ uid }}">{{ name }}</label>
                     </div>
                     {% endfor %}


### PR DESCRIPTION
## Summary
- allow selecting a single Plex user without preselection
- add function to retrieve Plex user tokens
- send Plex updates using the chosen user token

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684eebd4d2dc832eb684486a3d009f9f