### PR TITLE
Add user token listing for Plex accounts

### DIFF
--- a/plex_utils.py
+++ b/plex_utils.py
@@ -80,6 +80,29 @@ def get_user_token(plex, identifier: str) -> Optional[str]:
     return None
 
 
+def list_users_with_tokens(plex) -> List[Tuple[str, str, bool, Optional[str]]]:
+    """Return Plex users with their tokens.
+
+    Each tuple contains ``id``, ``name``, ``is_main`` and ``token``. ``is_main``
+    is ``True`` for the primary account and ``False`` for managed users.
+    """
+    users_info: List[Tuple[str, str, bool, Optional[str]]] = []
+    try:
+        account = plex.myPlexAccount()
+        main_id = str(account.id)
+        main_name = account.username or "unknown"
+        main_token = get_user_token(plex, main_id) or plex._token
+        users_info.append((main_id, main_name, True, main_token))
+        for user in account.users():
+            uid = str(user.id)
+            name = user.title
+            token = get_user_token(plex, uid)
+            users_info.append((uid, name, False, token))
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to list Plex users with tokens: %s", exc)
+    return users_info
+
+
 def get_plex_history(plex, accounts: Optional[List[str]] = None) -> Tuple[
     Dict[str, Dict[str, Optional[str]]],
     Dict[str, Dict[str, Optional[str]]],

--- a/templates/config.html
+++ b/templates/config.html
@@ -75,10 +75,14 @@
             <section class="card">
                 <h2>Users</h2>
                 <form method="post" class="user-form">
-                    {% for uid, name in plex_users %}
+                    {% for uid, name, is_main, token in plex_users %}
                     <div class="checkbox-group">
                         <input type="radio" id="user_{{ uid }}" name="account" value="{{ uid }}" {% if uid in selected_users %}checked{% endif %}>
-                        <label for="user_{{ uid }}">{{ name }}</label>
+                        <label for="user_{{ uid }}">
+                            {{ name }}
+                            {% if is_main %}(Main){% else %}(Managed){% endif %}
+                            <span class="token">{{ token }}</span>
+                        </label>
                     </div>
                     {% endfor %}
                     <div class="form-actions">


### PR DESCRIPTION
## Summary
- show managed users in Plex with their tokens
- log available users and tokens when connecting to Plex
- display user type and token in configuration UI

## Testing
- `python -m py_compile app.py plex_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f0e75d340832e99eb34b2e4780e2f