### PR TITLE
Add per-user watchlist sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ PlexyTrack now tries to obtain the token for any managed user selected via `PLEX
 4. Locate the entry with the matching user `id` and copy its `accessToken`.
 5. Use this token as `PLEX_TOKEN` when syncing that managed user.
 
+Watchlist synchronization also respects the selected Plex user and uses the retrieved token when adding or removing items.
+
 ## Getting Trakt API credentials
 
 1. Log in to your Trakt account and open <https://trakt.tv/oauth/applications>.

--- a/app.py
+++ b/app.py
@@ -113,7 +113,7 @@ werkzeug_logger.setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.2.7"
+APP_VERSION = "v0.2.8"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #
@@ -1364,12 +1364,23 @@ def sync():
                     logger.error("Liked-lists sync failed: %s", exc)
             if SYNC_WATCHLISTS:
                 try:
-                    sync_watchlist(
-                        plex,
-                        headers,
-                        plex_movie_guids | plex_episode_guids,
-                        trakt_movie_guids | trakt_episode_guids,
-                    )
+                    if PLEX_ACCOUNTS:
+                        for acc in PLEX_ACCOUNTS:
+                            token = get_user_token(plex, acc)
+                            sync_watchlist(
+                                plex,
+                                headers,
+                                plex_movie_guids | plex_episode_guids,
+                                trakt_movie_guids | trakt_episode_guids,
+                                token,
+                            )
+                    else:
+                        sync_watchlist(
+                            plex,
+                            headers,
+                            plex_movie_guids | plex_episode_guids,
+                            trakt_movie_guids | trakt_episode_guids,
+                        )
                 except TraktAccountLimitError as exc:
                     logger.error("Watchlist sync skipped: %s", exc)
                 except Exception as exc:
@@ -1494,7 +1505,12 @@ def sync():
         logger.warning("Ratings sync with Simkl is not yet supported.")
 
     if SYNC_WATCHLISTS and SYNC_PROVIDER == "trakt":
-        sync_watchlist(plex, headers, plex_movies, trakt_movies)
+        if PLEX_ACCOUNTS:
+            for acc in PLEX_ACCOUNTS:
+                token = get_user_token(plex, acc)
+                sync_watchlist(plex, headers, plex_movies, trakt_movies, token)
+        else:
+            sync_watchlist(plex, headers, plex_movies, trakt_movies)
     elif SYNC_WATCHLISTS and SYNC_PROVIDER == "simkl":
         logger.warning("Watchlist sync with Simkl is not yet supported.")
 

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -10,7 +10,7 @@ from utils import guid_to_ids, normalize_year, simkl_episode_key, to_iso_z
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.2.7"
+APP_VERSION = "v0.2.8"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 SIMKL_TOKEN_FILE = "simkl_tokens.json"

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -12,7 +12,7 @@ from utils import guid_to_ids, normalize_year, to_iso_z, valid_guid, best_guid, 
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.2.7"
+APP_VERSION = "v0.2.8"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 TOKEN_FILE = "trakt_tokens.json"
@@ -579,8 +579,18 @@ def sync_collections_to_trakt(plex, headers):
                     logger.error("Failed updating list %s: %s", slug, exc)
 
 
-def sync_watchlist(plex, headers, plex_history, trakt_history):
-    account = plex.myPlexAccount()
+def sync_watchlist(plex, headers, plex_history, trakt_history, token=None):
+    """Synchronize watchlists using the selected Plex account."""
+    account_server = plex
+    if token:
+        plex_baseurl = os.environ.get("PLEX_BASEURL")
+        try:
+            account_server = PlexServer(plex_baseurl, token)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to connect to Plex as %s: %s", token, exc)
+            account_server = plex
+
+    account = account_server.myPlexAccount()
     try:
         plex_watch = account.watchlist()
     except Exception as exc:
@@ -642,7 +652,7 @@ def sync_watchlist(plex, headers, plex_history, trakt_history):
                 guid = f"tmdb://{ids['tmdb']}"
             if not guid or guid in plex_guids:
                 continue
-            item = find_item_by_guid(plex, guid)
+            item = find_item_by_guid(account_server, guid)
             if item:
                 add_to_plex.append(item)
     if add_to_plex:
@@ -655,7 +665,7 @@ def sync_watchlist(plex, headers, plex_history, trakt_history):
     for guid in list(plex_guids):
         if guid in trakt_history or guid in plex_history:
             try:
-                item = find_item_by_guid(plex, guid)
+                item = find_item_by_guid(account_server, guid)
                 if item:
                     account.removeFromWatchlist([item])
             except Exception:


### PR DESCRIPTION
## Summary
- support syncing watchlist using selected Plex user token
- document that watchlist sync respects the selected user
- bump app version to v0.2.8

## Testing
- `find . -name "*.py" | xargs python -m py_compile`
- `pip install -r requirements.txt`
- `python - <<'PY'
import app, plex_utils, trakt_utils
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684f1a99ee70832ea7b9cc766e7475a6