### PR TITLE
Add guided Plex setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,11 +24,13 @@ from flask import (
     redirect,
     url_for,
     has_request_context,
+    session,
 )
 from flask import send_file
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.base import STATE_STOPPED
 from plexapi.server import PlexServer
+from plexapi.myplex import MyPlexAccount
 from plexapi.exceptions import BadRequest, NotFound
 
 from utils import (
@@ -133,6 +135,7 @@ PROVIDER_FILE = "provider.json"
 scheduler = BackgroundScheduler()
 plex = None  # will hold PlexServer instance
 USERS_FILE = "plex_users.json"
+PLEX_CREDS_FILE = "plex_credentials.json"
 PLEX_ACCOUNTS: List[str] = [
     a.strip() for a in os.environ.get("PLEX_ACCOUNT", "").split(",") if a.strip()
 ]
@@ -201,8 +204,36 @@ def save_plex_accounts(accounts: List[str]) -> None:
         logger.error("Failed to save Plex users: %s", exc)
 
 
+def load_plex_credentials() -> None:
+    """Load Plex base URL and token from file if not set."""
+    if os.environ.get("PLEX_BASEURL") and os.environ.get("PLEX_TOKEN"):
+        return
+    if os.path.exists(PLEX_CREDS_FILE):
+        try:
+            with open(PLEX_CREDS_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            os.environ.setdefault("PLEX_BASEURL", data.get("baseurl", ""))
+            os.environ.setdefault("PLEX_TOKEN", data.get("token", ""))
+            logger.info("Loaded Plex credentials from %s", PLEX_CREDS_FILE)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to load Plex credentials: %s", exc)
+
+
+def save_plex_credentials(baseurl: str, token: str) -> None:
+    """Persist Plex base URL and token to file."""
+    os.environ["PLEX_BASEURL"] = baseurl
+    os.environ["PLEX_TOKEN"] = token
+    try:
+        with open(PLEX_CREDS_FILE, "w", encoding="utf-8") as f:
+            json.dump({"baseurl": baseurl, "token": token}, f, indent=2)
+        logger.info("Saved Plex credentials to %s", PLEX_CREDS_FILE)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to save Plex credentials: %s", exc)
+
+
 def list_plex_users() -> List[Tuple[str, str, bool, Optional[str]]]:
     """Return available Plex users with token information."""
+    load_plex_credentials()
     plex_baseurl = os.environ.get("PLEX_BASEURL")
     plex_token = os.environ.get("PLEX_TOKEN")
     if not plex_baseurl or not plex_token:
@@ -1678,6 +1709,7 @@ def index():
     load_trakt_tokens()
     load_simkl_tokens()
     load_provider()
+    load_plex_credentials()
 
     # Change interval and start sync when requested
     if request.method == "POST":
@@ -1762,12 +1794,71 @@ def simkl_callback():
     return redirect(url_for("oauth_callback", service="simkl", code=code))
 
 
+@app.route("/plex_setup", methods=["GET", "POST"])
+def plex_setup():
+    """Interactive Plex login and server/user selection."""
+    step = request.args.get("step", "login")
+    error = None
+    if step == "login":
+        if request.method == "POST":
+            username = request.form.get("username", "").strip()
+            password = request.form.get("password", "").strip()
+            code = request.form.get("code", "").strip() or None
+            try:
+                account = MyPlexAccount(username=username, password=password, code=code)
+                session["plex_token"] = account._token
+                servers = []
+                for res in account.resources():
+                    if "server" in res.provides:
+                        conn = res.connections[0]
+                        servers.append({
+                            "id": res.clientIdentifier,
+                            "name": res.name,
+                            "uri": conn.uri,
+                            "token": res.accessToken,
+                        })
+                session["plex_servers"] = servers
+                return redirect(url_for("plex_setup", step="server"))
+            except Exception as exc:  # noqa: BLE001
+                error = f"Login failed: {exc}"
+        return render_template("plex_setup.html", step="login", error=error)
+
+    if step == "server":
+        servers = session.get("plex_servers", [])
+        if request.method == "POST":
+            sid = request.form.get("server")
+            srv = next((s for s in servers if s["id"] == sid), None)
+            if srv:
+                save_plex_credentials(srv["uri"], srv["token"])
+                session.pop("plex_servers", None)
+                return redirect(url_for("plex_setup", step="user"))
+        return render_template("plex_setup.html", step="server", servers=servers)
+
+    if step == "user":
+        load_plex_credentials()
+        plex_baseurl = os.environ.get("PLEX_BASEURL")
+        plex_token = os.environ.get("PLEX_TOKEN")
+        if not plex_baseurl or not plex_token:
+            return redirect(url_for("plex_setup"))
+        server = PlexServer(plex_baseurl, plex_token)
+        users = list_users_with_tokens(server)
+        if request.method == "POST":
+            selected = request.form.get("account")
+            if selected:
+                save_plex_accounts([selected])
+            return redirect(url_for("config_page"))
+        return render_template("plex_setup.html", step="user", users=users)
+
+    return redirect(url_for("config_page"))
+
+
 @app.route("/config", methods=["GET", "POST"])
 def config_page():
     """Display configuration status for Trakt and Simkl."""
     load_trakt_tokens()
     load_simkl_tokens()
     load_provider()
+    load_plex_credentials()
     load_plex_accounts()
     plex_users = list_plex_users()
     if request.method == "POST":
@@ -1951,6 +2042,7 @@ def plex_webhook():
 # --------------------------------------------------------------------------- #
 def test_connections() -> bool:
     global plex
+    load_plex_credentials()
     plex_baseurl = os.environ.get("PLEX_BASEURL")
     plex_token = os.environ.get("PLEX_TOKEN")
     trakt_token = os.environ.get("TRAKT_ACCESS_TOKEN")

--- a/templates/config.html
+++ b/templates/config.html
@@ -74,6 +74,7 @@
 
             <section class="card">
                 <h2>Users</h2>
+                {% if plex_users %}
                 <form method="post" class="user-form">
                     {% for uid, name, is_main, token in plex_users %}
                     <div class="checkbox-group">
@@ -92,6 +93,10 @@
                 <form method="get" action="{{ url_for('config_page') }}" class="stop-form">
                     <button type="submit" class="button secondary">Update Users</button>
                 </form>
+                {% else %}
+                <p>No Plex credentials configured.</p>
+                <a href="{{ url_for('plex_setup') }}" class="button primary">Configure Plex</a>
+                {% endif %}
             </section>
         </main>
 

--- a/templates/plex_setup.html
+++ b/templates/plex_setup.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PlexyTrack - Plex Setup</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
+</head>
+<body>
+    <div class="app-container">
+        <header class="app-header">
+            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+            <h1>PlexyTrack</h1>
+            <nav class="app-nav">
+                <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
+                <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
+                <a href="{{ url_for('config_page') }}" class="nav-link active">Config.</a>
+                <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
+            </nav>
+        </header>
+
+        <main class="content-area">
+            {% if step == 'login' %}
+            <section class="card">
+                <h2>Plex Login</h2>
+                {% if error %}<div class="status-message error">{{ error }}</div>{% endif %}
+                <form method="post">
+                    <div class="form-group">
+                        <label for="username">Username or Email</label>
+                        <input type="text" id="username" name="username" required class="form-input">
+                    </div>
+                    <div class="form-group">
+                        <label for="password">Password</label>
+                        <input type="password" id="password" name="password" required class="form-input">
+                    </div>
+                    <div class="form-group">
+                        <label for="code">2FA Code (optional)</label>
+                        <input type="text" id="code" name="code" class="form-input">
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="button primary">Login</button>
+                    </div>
+                </form>
+            </section>
+            {% elif step == 'server' %}
+            <section class="card">
+                <h2>Select Plex Server</h2>
+                <form method="post">
+                    {% for srv in servers %}
+                    <div class="checkbox-group">
+                        <input type="radio" id="srv_{{ srv.id }}" name="server" value="{{ srv.id }}" {% if loop.first %}checked{% endif %}>
+                        <label for="srv_{{ srv.id }}">{{ srv.name }}</label>
+                    </div>
+                    {% endfor %}
+                    <div class="form-actions">
+                        <button type="submit" class="button primary">Save</button>
+                    </div>
+                </form>
+            </section>
+            {% elif step == 'user' %}
+            <section class="card">
+                <h2>Select Plex User</h2>
+                <form method="post">
+                    {% for uid, name, is_main, token in users %}
+                    <div class="checkbox-group">
+                        <input type="radio" id="user_{{ uid }}" name="account" value="{{ uid }}" {% if loop.first %}checked{% endif %}>
+                        <label for="user_{{ uid }}">{{ name }} {% if is_main %}(Main){% else %}(Managed){% endif %}</label>
+                    </div>
+                    {% endfor %}
+                    <div class="form-actions">
+                        <button type="submit" class="button primary">Save</button>
+                    </div>
+                </form>
+            </section>
+            {% endif %}
+        </main>
+
+        <footer class="app-footer">
+            <p>MIT License. By <a href="https://github.com/Drakonis96" target="_blank" rel="noopener">Drakonis96</a></p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- guide Plex setup with login, server selection and managed user choice
- store Plex credentials for reuse
- show configure button in Config page when Plex is not set up

## Testing
- `python -m py_compile app.py plex_utils.py trakt_utils.py simkl_utils.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1f097714832e9241b9f0a909433b