### PR TITLE
Fix Plex connection check for home user tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -2239,7 +2239,10 @@ def test_connections() -> bool:
 
     try:
         plex = PlexServer(plex_baseurl, plex_token)
-        plex.account()
+        # Calling ``plex.account()`` fails with home user tokens. Fetching the
+        # library sections is sufficient to validate the connection for both
+        # admin and managed users.
+        plex.library.sections()
         logger.info("Successfully connected to Plex.")
     except Exception as exc:
         logger.error("Failed to connect to Plex: %s", exc)


### PR DESCRIPTION
## Summary
- fix the connection test for Plex so managed users don't fail

## Testing
- `python -m py_compile app.py plex_utils.py trakt_utils.py simkl_utils.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f57443718832eaceca219912819c9