### PR TITLE
Fix Plex login retrieval of server list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,5 @@ SIMKL_CLIENT_SECRET=YOUR_SIMKL_CLIENT_SECRET
 # Optional Plex tokens for managed or shared servers
 # PLEX_OWNER_TOKEN=
 # PLEX_ACCOUNT_TOKEN=
+# PLEX_USER_ID=
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This application is currently in testing and is provided **as is**. I take no re
 - `TZ` – timezone for log timestamps, defaults to `Europe/Madrid`.
 - `PLEX_OWNER_TOKEN` – optional token of the Plex server owner when using a managed user.
 - `PLEX_ACCOUNT_TOKEN` – optional token for a shared server when you don't own it.
+- `PLEX_USER_ID` – optional Plex user id corresponding to the selected profile.
 
 
 At least one pair of Trakt or Simkl credentials is required. Plex tokens and the

--- a/app.py
+++ b/app.py
@@ -1947,7 +1947,7 @@ def login_page():
                 servers = session.get("servers", [])
                 info = next(s for s in servers if s["name"] == server_name)
                 server = PlexServer(info["baseurl"], session.get("account_token"))
-                session["server_name"] = info["name"]
+                session["server_name"] = getattr(server, "friendlyName", None) or info["name"]
                 session["server_token"] = session.get("account_token")
                 session["machine_id"] = info.get("machine_id")
                 session["baseurl"] = info["baseurl"]

--- a/app.py
+++ b/app.py
@@ -724,6 +724,7 @@ def get_account_servers(token: str) -> List[dict]:
                     "source": res.get("sourceTitle", ""),
                     "machine_id": res.get("clientIdentifier"),
                     "baseurl": baseurl,
+                    "token": res.get("accessToken"),
                 }
             )
     except Exception as exc:  # noqa: BLE001
@@ -750,6 +751,7 @@ def get_account_servers(token: str) -> List[dict]:
                         "source": getattr(res, "sourceTitle", ""),
                         "machine_id": res.clientIdentifier,
                         "baseurl": baseurl,
+                        "token": getattr(res, "accessToken", None),
                     }
                 )
         except Exception as exc:  # noqa: BLE001
@@ -1987,7 +1989,8 @@ def login_page():
                 servers = session.get("servers", [])
                 info = next(s for s in servers if s["name"] == server_name)
                 baseurl = info.get("baseurl")
-                if not baseurl:
+                token = info.get("token")
+                if not baseurl or not token:
                     account = MyPlexAccount(token=session.get("account_token"))
                     resource = next(
                         r
@@ -1996,10 +1999,11 @@ def login_page():
                     )
                     server = resource.connect()
                     baseurl = server._baseurl
+                    token = server._token
                 else:
-                    server = PlexServer(baseurl, session.get("account_token"))
+                    server = PlexServer(baseurl, token)
                 session["server_name"] = getattr(server, "friendlyName", None) or info["name"]
-                session["server_token"] = session.get("account_token")
+                session["server_token"] = token
                 session["machine_id"] = info.get("machine_id")
                 session["baseurl"] = baseurl
                 session["owned"] = info.get("owned", False)

--- a/app.py
+++ b/app.py
@@ -2037,9 +2037,9 @@ def login_page():
                 if session.get("owned"):
                     if selected_user and selected_user != user:
                         owner_token = token
-                        role = {u: r for u, r, _ in session.get("users", [])}.get(selected_user)
-                        if role != "managed":
-                            token = account.user(selected_user).get_token(session.get("machine_id"))
+                        token = account.user(selected_user).get_token(
+                            session.get("machine_id")
+                        )
                         user = selected_user
                 else:
                     account_token = account.authenticationToken

--- a/app.py
+++ b/app.py
@@ -1991,7 +1991,9 @@ def login_page():
                 if session.get("owned"):
                     if selected_user and selected_user != user:
                         owner_token = token
-                        token = account.user(selected_user).get_token(session.get("machine_id"))
+                        role = dict(session.get("users", [])).get(selected_user)
+                        if role != "managed":
+                            token = account.user(selected_user).get_token(session.get("machine_id"))
                         user = selected_user
                 else:
                     account_token = account.authenticationToken
@@ -2306,7 +2308,10 @@ def test_connections() -> bool:
 
     try:
         plex = PlexServer(plex_baseurl, plex_token)
-        plex.account()
+        if os.environ.get("PLEX_OWNER_TOKEN"):
+            plex.library.sections()
+        else:
+            plex.account()
         logger.info("Successfully connected to Plex.")
     except Exception as exc:
         logger.error("Failed to connect to Plex: %s", exc)

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -11,10 +11,21 @@ from utils import (
     find_item_by_guid,
 )
 
+
+def _mark_watched(item, account_id: Optional[int] = None) -> None:
+    """Mark `item` as watched optionally for a specific account."""
+    params = {
+        "key": item.ratingKey,
+        "identifier": "com.plexapp.plugins.library",
+    }
+    if account_id is not None:
+        params["accountID"] = account_id
+    item._server.query("/:/scrobble", params=params)
+
 logger = logging.getLogger(__name__)
 
 
-def get_plex_history(plex) -> Tuple[
+def get_plex_history(plex, account_id: Optional[int] = None) -> Tuple[
     Dict[str, Dict[str, Optional[str]]],
     Dict[str, Dict[str, Optional[str]]],
 ]:
@@ -24,7 +35,8 @@ def get_plex_history(plex) -> Tuple[
     show_guid_cache: Dict[str, Optional[str]] = {}
 
     logger.info("Fetching Plex history…")
-    for entry in plex.history():
+    history_kwargs = {"accountID": account_id} if account_id else {}
+    for entry in plex.history(**history_kwargs):
         watched_at = to_iso_z(getattr(entry, "viewedAt", None))
 
         if entry.type == "movie":
@@ -89,8 +101,9 @@ def get_plex_history(plex) -> Tuple[
     logger.info("Fetching watched flags from Plex library…")
     for section in plex.library.sections():
         try:
+            search_kwargs = {"accountID": account_id} if account_id else {}
             if section.type == "movie":
-                for item in section.search(viewCount__gt=0):
+                for item in section.search(viewCount__gt=0, **search_kwargs):
                     title = item.title
                     year = normalize_year(getattr(item, "year", None))
                     guid = imdb_guid(item)
@@ -102,7 +115,7 @@ def get_plex_history(plex) -> Tuple[
                             "guid": guid,
                         }
             elif section.type == "show":
-                for ep in section.searchEpisodes(viewCount__gt=0):
+                for ep in section.searchEpisodes(viewCount__gt=0, **search_kwargs):
                     code = f"S{int(ep.seasonNumber):02d}E{int(ep.episodeNumber):02d}"
                     guid = imdb_guid(ep)
                     show_title = getattr(ep, "grandparentTitle", None)
@@ -124,6 +137,7 @@ def update_plex(
     plex,
     movies: Set[Tuple[str, Optional[int], Optional[str]]],
     episodes: Set[Tuple[str, str, Optional[str]]],  # Only allow str for key, not Tuple fallback
+    account_id: Optional[int] = None,
 ) -> None:
     """Mark items as watched in Plex when missing."""
     movie_count = 0
@@ -136,7 +150,7 @@ def update_plex(
                 if item and getattr(item, "isWatched", lambda: bool(getattr(item, "viewCount", 0)))():
                     continue
                 if item:
-                    item.markWatched()
+                    _mark_watched(item, account_id)
                     movie_count += 1
                     continue
             except Exception as exc:
@@ -166,7 +180,7 @@ def update_plex(
             is_watched = getattr(found, "isWatched", False) or bool(getattr(found, "viewCount", 0))
             if is_watched:
                 continue
-            found.markWatched()
+            _mark_watched(found, account_id)
             movie_count += 1
         except Exception as exc:
             logger.debug("Failed to mark movie '%s' as watched: %s", found.title, exc)
@@ -185,7 +199,7 @@ def update_plex(
                     is_watched = getattr(item, "isWatched", False) or bool(getattr(item, "viewCount", 0))
                     if is_watched:
                         continue
-                    item.markWatched()
+                    _mark_watched(item, account_id)
                     episode_count += 1
                     continue
             except Exception as exc:
@@ -209,7 +223,7 @@ def update_plex(
             is_watched = getattr(ep_obj, "isWatched", False) or bool(getattr(ep_obj, "viewCount", 0))
             if is_watched:
                 continue
-            ep_obj.markWatched()
+            _mark_watched(ep_obj, account_id)
             episode_count += 1
         except Exception as exc:
             logger.debug("Failed marking episode %s - %s as watched: %s", show_title, code, exc)

--- a/templates/login.html
+++ b/templates/login.html
@@ -73,7 +73,7 @@
                     <div class="form-group">
                         <label for="user">User:</label>
                         <select name="user" id="user" class="form-input">
-                            {% for u, role in users %}
+                            {% for u, role, _id in users %}
                             <option value="{{ u }}">{{ u }} ({{ role }})</option>
                             {% endfor %}
                         </select>

--- a/templates/login.html
+++ b/templates/login.html
@@ -54,7 +54,11 @@
                     <div class="form-group">
                         <label for="server">Server:</label>
                         <select name="server" id="server" class="form-input">
-                            {% for s in servers %}<option value="{{ s }}">{{ s }}</option>{% endfor %}
+                            {% for s in servers %}
+                            <option value="{{ s.name }}">
+                                {{ s.name }}{% if s.owned %} (owned){% elif s.source %} ({{ s.source }}){% endif %}
+                            </option>
+                            {% endfor %}
                         </select>
                     </div>
                     <button type="submit" class="button primary">Continue</button>
@@ -69,7 +73,9 @@
                     <div class="form-group">
                         <label for="user">User:</label>
                         <select name="user" id="user" class="form-input">
-                            {% for u in users %}<option value="{{ u }}">{{ u }}</option>{% endfor %}
+                            {% for u, role in users %}
+                            <option value="{{ u }}">{{ u }} ({{ role }})</option>
+                            {% endfor %}
                         </select>
                     </div>
                     <button type="submit" class="button primary">Finish</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -81,6 +81,18 @@
                     <button type="submit" class="button primary">Finish</button>
                 </form>
             </section>
+            {% elif stage == 4 %}
+            <section class="card">
+                <h2>Plex Connection</h2>
+                {% if message %}
+                <div class="status-message {{ mtype }}">{{ message }}</div>
+                {% endif %}
+                <p><strong>Server:</strong> {{ server }}</p>
+                <p><strong>User:</strong> {{ username }}</p>
+                <form action="{{ url_for('clear_service', service='plex') }}" method="post">
+                    <button type="submit" class="button danger">Logout</button>
+                </form>
+            </section>
             {% endif %}
         </main>
 


### PR DESCRIPTION
## Summary
- correct server list retrieval for Plex login
- show server owner and user role during login

## Testing
- `python3 -m py_compile app.py plex_utils.py trakt_utils.py simkl_utils.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ff131db2c832e856de4762cb0e1c1