### PR TITLE
Handle managed Plex user tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -1177,7 +1177,8 @@ def get_plex_history(plex, account_id: Optional[int] = None) -> Tuple[
     show_guid_cache: Dict[str, Optional[str]] = {}
 
     logger.info("Fetching Plex history…")
-    history_kwargs = {"accountID": account_id} if account_id else {}
+    is_owner = os.environ.get("PLEX_OWNER_TOKEN") == getattr(plex, "_token", None)
+    history_kwargs = {"accountID": account_id} if (account_id and is_owner) else {}
     for entry in plex.history(**history_kwargs):
         watched_at = to_iso_z(getattr(entry, "viewedAt", None))
 

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -36,8 +36,7 @@ def get_plex_history(plex, account_id: Optional[int] = None) -> Tuple[
     show_guid_cache: Dict[str, Optional[str]] = {}
 
     logger.info("Fetching Plex history…")
-    is_owner = os.environ.get("PLEX_OWNER_TOKEN") == getattr(plex, "_token", None)
-    history_kwargs = {"accountID": account_id} if (account_id and is_owner) else {}
+    history_kwargs = {"accountID": account_id} if account_id else {}
     for entry in plex.history(**history_kwargs):
         watched_at = to_iso_z(getattr(entry, "viewedAt", None))
 

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import Dict, Optional, Set, Tuple
 
 from utils import (

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Dict, Optional, Set, Tuple
 
 from utils import (
@@ -35,7 +36,8 @@ def get_plex_history(plex, account_id: Optional[int] = None) -> Tuple[
     show_guid_cache: Dict[str, Optional[str]] = {}
 
     logger.info("Fetching Plex history…")
-    history_kwargs = {"accountID": account_id} if account_id else {}
+    is_owner = os.environ.get("PLEX_OWNER_TOKEN") == getattr(plex, "_token", None)
+    history_kwargs = {"accountID": account_id} if (account_id and is_owner) else {}
     for entry in plex.history(**history_kwargs):
         watched_at = to_iso_z(getattr(entry, "viewedAt", None))
 


### PR DESCRIPTION
## Summary
- limit `accountID` parameter to owner token for history retrieval
- keep Plex utils consistent with the same logic

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685067e00338832e9a5b1b77cf02441a