### PR TITLE
Add per-user sync via scrobble

### DIFF
--- a/templates/users.html
+++ b/templates/users.html
@@ -350,6 +350,16 @@
             if (!loadState()) {
                 updateStepVisuals();
             }
+
+            // Load server-side selected user if not in state
+            fetch('/api/selected_user')
+                .then(r => r.json())
+                .then(data => {
+                    if (data.user_id && !selectedUser) {
+                        selectedUser = { id: data.user_id };
+                    }
+                })
+                .catch(() => {});
             
             // Add logout button event listener
             document.getElementById('logoutBtn').addEventListener('click', async function() {
@@ -582,7 +592,14 @@
         // Select user
         function selectUser(user) {
             selectedUser = user;
-            
+
+            // Persist selection server-side
+            fetch('/api/selected_user', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ user_id: user.id })
+            }).catch(() => {});
+
             // Update visual selection
             document.querySelectorAll('.user-item').forEach(el => {
                 el.classList.remove('selected');


### PR DESCRIPTION
## Summary
- track selected Plex user in a `selected_user.json` file
- save or load the selected user through new `/api/selected_user` endpoint
- persist selection when choosing a user in the UI
- sync only the stored user; managed users use scrobble endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851ac65770c832e9693d8184b1e1339