### PR TITLE
Fix timestamp saving after sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -1946,8 +1946,8 @@ def sync():
         if SYNC_PROVIDER == "trakt":
             logger.info("Provider: Trakt")
             last_sync = load_trakt_last_sync_date()
-            current_activity = get_trakt_last_activity(headers)
-            if last_sync and current_activity and current_activity == last_sync:
+            current_activity_before = get_trakt_last_activity(headers)
+            if last_sync and current_activity_before and current_activity_before == last_sync:
                 logger.info("No new Trakt activity since %s", last_sync)
                 trakt_movies, trakt_episodes = {}, {}
             else:
@@ -2084,14 +2084,17 @@ def sync():
                 except Exception as exc:
                     logger.error("Watchlist sync failed: %s", exc)
 
-            if current_activity:
-                save_trakt_last_sync_date(current_activity)
+            current_activity_after = get_trakt_last_activity(headers)
+            if current_activity_after:
+                save_trakt_last_sync_date(current_activity_after)
+            elif current_activity_before:
+                save_trakt_last_sync_date(current_activity_before)
 
         elif SYNC_PROVIDER == "simkl":
             logger.info("Provider: Simkl")
             last_sync = load_last_sync_date()
-            current_activity = get_last_activity(headers)
-            if last_sync and current_activity and current_activity == last_sync:
+            current_activity_before = get_last_activity(headers)
+            if last_sync and current_activity_before and current_activity_before == last_sync:
                 logger.info("No new Simkl activity since %s", last_sync)
                 simkl_movies, simkl_episodes = {}, {}
             else:
@@ -2188,8 +2191,11 @@ def sync():
                     logger.info("Skipping bidirectional sync for managed user %s: %d movies and %d episodes would have been synced from Simkl to Plex", 
                                selected_user["username"], len(movies_to_add_plex), len(episodes_to_add_plex))
 
-            if current_activity:
-                save_last_sync_date(current_activity)
+            current_activity_after = get_last_activity(headers)
+            if current_activity_after:
+                save_last_sync_date(current_activity_after)
+            elif current_activity_before:
+                save_last_sync_date(current_activity_before)
 
     except Exception as exc:  # noqa: BLE001
         logger.error("Error during sync: %s", exc)

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -230,8 +230,12 @@ def get_owner_plex_history(account, mindate: Optional[str] = None) -> Tuple[
                                     watched_at = to_iso_z(getattr(last_viewed, "viewedAt", None))
                                 else:
                                     # Manually marked as watched but no history entry
-                                    # Use dateAdded or updatedAt as fallback timestamp
-                                    fallback_date = getattr(movie, 'updatedAt', None) or getattr(movie, 'addedAt', None)
+                                    # Use lastViewedAt, updatedAt or addedAt as fallback timestamp
+                                    fallback_date = (
+                                        getattr(movie, 'lastViewedAt', None)
+                                        or getattr(movie, 'updatedAt', None)
+                                        or getattr(movie, 'addedAt', None)
+                                    )
                                     watched_at = to_iso_z(fallback_date)
                                 movies[guid] = {
                                     "title": title,
@@ -265,8 +269,12 @@ def get_owner_plex_history(account, mindate: Optional[str] = None) -> Tuple[
                                     watched_at = to_iso_z(getattr(last_viewed, "viewedAt", None))
                                 else:
                                     # Manually marked as watched but no history entry
-                                    # Use dateAdded or updatedAt as fallback timestamp
-                                    fallback_date = getattr(episode, 'updatedAt', None) or getattr(episode, 'addedAt', None)
+                                    # Use lastViewedAt, updatedAt or addedAt as fallback timestamp
+                                    fallback_date = (
+                                        getattr(episode, 'lastViewedAt', None)
+                                        or getattr(episode, 'updatedAt', None)
+                                        or getattr(episode, 'addedAt', None)
+                                    )
                                     watched_at = to_iso_z(fallback_date)
                                 episodes[guid] = {
                                     "show": show_title,
@@ -454,7 +462,11 @@ def get_managed_user_plex_history(account, user_id, server_name=None, mindate: O
                                     
                                     # If no timestamp in history, use fallback
                                     if not watched_at:
-                                        fallback_date = getattr(movie, 'updatedAt', None) or getattr(movie, 'addedAt', None)
+                                        fallback_date = (
+                                            getattr(movie, 'lastViewedAt', None)
+                                            or getattr(movie, 'updatedAt', None)
+                                            or getattr(movie, 'addedAt', None)
+                                        )
                                         watched_at = to_iso_z(fallback_date)
                                         logger.debug("Added manually marked movie with fallback timestamp - Movie: %s (%s)", title, year)
                                     else:
@@ -504,7 +516,11 @@ def get_managed_user_plex_history(account, user_id, server_name=None, mindate: O
                                     
                                     # If no timestamp in history, use fallback
                                     if not watched_at:
-                                        fallback_date = getattr(episode, 'updatedAt', None) or getattr(episode, 'addedAt', None)
+                                        fallback_date = (
+                                            getattr(episode, 'lastViewedAt', None)
+                                            or getattr(episode, 'updatedAt', None)
+                                            or getattr(episode, 'addedAt', None)
+                                        )
                                         watched_at = to_iso_z(fallback_date)
                                         logger.debug("Added manually marked episode with fallback timestamp - Episode: %s %s", show_title, code)
                                     else:

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 def to_iso_z(value) -> Optional[str]:
     """Convert any ``viewedAt`` variant to ISO-8601 UTC ("...Z")."""
-    if value is None:
+    if value is None or value == 0 or value == "0":
         return None
 
     if isinstance(value, datetime):


### PR DESCRIPTION
## Summary
- update Trakt/Simkl last activity timestamps after items are synced

## Testing
- `python -m py_compile app.py simkl_utils.py trakt_utils.py plex_utils.py utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530df57ed8832eb39b8a086bca6403