### PR TITLE
Simplify users tab and sync selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,7 +105,7 @@ werkzeug_logger.setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.2.7"
+APP_VERSION = "v0.3.0-experimental"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -10,7 +10,7 @@ from utils import guid_to_ids, normalize_year, simkl_episode_key, to_iso_z
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.2.7"
+APP_VERSION = "v0.3.0-experimental"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 SIMKL_TOKEN_FILE = "simkl_tokens.json"

--- a/templates/users.html
+++ b/templates/users.html
@@ -260,16 +260,6 @@
                     </div>
                 </div>
 
-                <!-- Step 4: History Display -->
-                <div class="step-container" id="step4" data-step="4">
-                    <div class="step-header">
-                        <div class="step-number">4</div>
-                        <div class="step-title">User Statistics & History</div>
-                    </div>
-                    <div id="historyContent" class="history-section">
-                        <p>Please select a user first to see their viewing statistics and history.</p>
-                    </div>
-                </div>
             </section>
         </main>
 
@@ -338,9 +328,6 @@
                     if (currentStep >= 3 && selectedServer && authToken) {
                         setTimeout(() => loadUsers(), 200);
                     }
-                    if (currentStep >= 4 && selectedUser && authToken) {
-                        setTimeout(() => loadUserStatsAndHistory(), 300);
-                    }
                     
                     return true;
                 } catch (e) {
@@ -370,7 +357,6 @@
             updateStepVisuals();
             document.getElementById('serverList').innerHTML = '<p>Please authenticate first to see available servers.</p>';
             document.getElementById('userList').innerHTML = '<p>Please select a server first to see available users.</p>';
-            document.getElementById('historyContent').innerHTML = '<p>Please select a user first to see their viewing statistics and history.</p>';
             
             // Clear any error/success messages
             document.getElementById('authError').style.display = 'none';
@@ -430,10 +416,10 @@
 
         // Update step visual states
         function updateStepVisuals() {
-            for (let i = 1; i <= 4; i++) {
+            for (let i = 1; i <= 3; i++) {
                 const stepEl = document.getElementById(`step${i}`);
                 stepEl.classList.remove('active', 'completed');
-                
+
                 if (i < currentStep) {
                     stepEl.classList.add('completed');
                 } else if (i === currentStep) {
@@ -654,22 +640,20 @@
             }
         }
 
-        // Select user for viewing history (existing function)
+        // Select user by clicking on the row
         function selectUser(user) {
             selectedUser = user;
-            
-            // Update visual selection
+
+            // Highlight selection
             document.querySelectorAll('.user-item').forEach(el => {
                 el.classList.remove('selected');
             });
             event.target.closest('.user-item').classList.add('selected');
-            
-            currentStep = 4;
-            updateStepVisuals();
-            saveState(); // Save state after user selection
-            
-            // Immediately load both stats and history when user is selected
-            loadUserStatsAndHistory();
+
+            saveState();
+
+            // Trigger the same action as the "Select for Sync" button
+            selectForSync(user);
         }
 
         // Step 4: Load user stats and history automatically

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -12,7 +12,7 @@ from utils import guid_to_ids, normalize_year, to_iso_z, valid_guid, best_guid, 
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.2.7"
+APP_VERSION = "v0.3.0-experimental"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 TOKEN_FILE = "trakt_tokens.json"


### PR DESCRIPTION
## Summary
- remove the statistics & history panel from the users page
- clicking a user now triggers the same sync selection action as the button
- keep request version bumped to `v0.3.0-experimental`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68531c593bc4832eba3a3303a80ee8b0