### PR TITLE
feat: sync watchlist removals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ simkl_tokens.json
 provider.json
 selected_user.json
 settings.json
+watchlist_state.json


### PR DESCRIPTION
## Summary
- cache watchlists to avoid full scans
- sync removals between Plex and Trakt in both directions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68907ef3695c832ebd6ae22d683636da