### PR TITLE
Add Sync Once option and rename Start Sync button

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ file:
 docker-compose -f docker-compose-local.yml up --build
 ```
 
-4. Visit `http://localhost:5030` in your browser. You can adjust the sync interval on the page. The **Start Sync** button schedules the job, while **Stop Sync** now immediately cancels any running sync and removes future scheduled jobs.
+4. Visit `http://localhost:5030` in your browser. You can adjust the sync interval on the page. Use **Sync Once** to run an immediate one-time sync—ideal for the initial sync of large libraries. Use **Schedule Sync** to set up a recurring job, and **Stop Sync** to immediately cancel any running or scheduled syncs.
 
    A sync interval of **at least 60 minutes is recommended**. Shorter intervals are generally unnecessary, and you can even schedule the job every 24 hours to reduce the load on your server and the Trakt or Simkl API.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -171,9 +171,13 @@
                     </fieldset>
                     
                     <div class="form-actions">
-                        <button type="submit" id="syncBtn" class="button primary">
+                        <button type="submit" id="scheduleBtn" class="button primary">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM10.6212 15.5354L12.0354 16.9496L16.9496 12.0354L15.5354 10.6212L12.0354 14.1212L9.20702 11.2928L7.79281 12.707L10.6212 15.5354Z"></path></svg>
-                            Start Sync
+                            Schedule Sync
+                        </button>
+                        <button type="submit" formaction="{{ url_for('sync_once') }}" id="syncOnceBtn" class="button primary">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM10.6212 15.5354L12.0354 16.9496L16.9496 12.0354L15.5354 10.6212L12.0354 14.1212L9.20702 11.2928L7.79281 12.707L10.6212 15.5354Z"></path></svg>
+                            Sync Once
                         </button>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- Rename **Start Sync** to **Schedule Sync** and add a new **Sync Once** button in the sync settings
- Implement `/sync_once` route to run an immediate one-time sync without scheduling
- Document the new workflow, recommending Sync Once for initial large syncs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689082d8e060832e935d182878334ef9