### PR TITLE
feat: persist last Plex sync timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ provider.json
 selected_user.json
 settings.json
 watchlist_state.json
+plex_sync_state.json


### PR DESCRIPTION
## Summary
- track last successful Plex sync in plex_sync_state.json
- pass mindate to history calls and filter entries based on timestamp
- load and save Plex sync timestamp during synchronization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689090d2c524832eb88604c21d999642