### PR TITLE
Handle legacy state migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ docker-compose -f docker-compose-local.yml up --build
 
 That's it! The container will continue to sync your Plex account with Trakt and/or Simkl according to the interval you set.
 
+## Upgrade guide
+
+Upgrading from earlier versions requires no manual steps. On startup the
+application automatically migrates any legacy state and continues syncing
+without a full rescan.
+
 ## User Selection
 
 When using PlexyTrack with multiple Plex users (owner and managed users), you can choose which user's viewing history to synchronize.

--- a/app.py
+++ b/app.py
@@ -65,6 +65,7 @@ from plex_utils import (
     load_last_plex_sync,
     save_last_plex_sync,
     load_state,
+    migrate_legacy_state,
 )
 from trakt_utils import (
     trakt_request,
@@ -3885,6 +3886,7 @@ def clear_session_credentials():
 if __name__ == "__main__":
     logger.info("Starting PlexyTrackt application")
     verify_volume(CONFIG_DIR, "config")
+    migrate_legacy_state()
     verify_volume(STATE_DIR, "state")
     state_data = load_state()
     load_trakt_tokens()

--- a/tests/test_state_migration.py
+++ b/tests/test_state_migration.py
@@ -1,0 +1,57 @@
+import json
+import importlib
+
+
+def setup_modules(tmp_path, monkeypatch):
+    monkeypatch.setenv("PLEXYTRACK_DATA_DIR", str(tmp_path))
+    plex_utils = importlib.reload(importlib.import_module("plex_utils"))
+    app = importlib.reload(importlib.import_module("app"))
+    return plex_utils, app
+
+
+def test_migrates_v1_state_no_safe_mode(tmp_path, monkeypatch):
+    plex_utils, _ = setup_modules(tmp_path, monkeypatch)
+    legacy = {"lastSync": "2024-01-01T00:00:00Z", "guid_cache": {"x": "y"}}
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "state.json").write_text(json.dumps(legacy))
+
+    plex_utils.migrate_legacy_state()
+    state = plex_utils.load_state()
+
+    assert state["schema"] == 2
+    assert state["lastSync"] == legacy["lastSync"]
+    assert state["guid_cache"] == legacy["guid_cache"]
+    assert not (config_dir / "state.json").exists()
+
+    sync_watched = False
+    safe_mode = state.get("lastSync") is None and not sync_watched
+    assert not safe_mode
+
+
+def test_token_refresh_with_migrated_state(tmp_path, monkeypatch):
+    plex_utils, app = setup_modules(tmp_path, monkeypatch)
+    monkeypatch.setenv("TRAKT_CLIENT_ID", "cid")
+    monkeypatch.setenv("TRAKT_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("TRAKT_REFRESH_TOKEN", "old")
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "state.json").write_text(json.dumps({"lastSync": "2024-01-01T00:00:00Z"}))
+
+    plex_utils.migrate_legacy_state()
+
+    class DummyResp:
+        status_code = 200
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return {"access_token": "new", "refresh_token": "new", "expires_in": 3600}
+
+    monkeypatch.setattr(app.requests, "post", lambda *a, **k: DummyResp())
+    app.refresh_trakt_token()
+
+    state = plex_utils.load_state()
+    sync_watched = False
+    safe_mode = state.get("lastSync") is None and not sync_watched
+    assert not safe_mode


### PR DESCRIPTION
## Summary
- migrate legacy `state.json` to new `state/` layout and mark schema 2
- invoke migration before loading state to preserve history
- document automatic upgrade procedure and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f64038fc832ebb17578eadae2f53