### PR TITLE
Ignore non-play Plex history entries

### DIFF
--- a/plex_utils.py
+++ b/plex_utils.py
@@ -229,6 +229,12 @@ def get_owner_plex_history(account, mindate: Optional[str] = None) -> Tuple[
 
         for entry in history_items:
             watched_at = to_iso_z(getattr(entry, "viewedAt", None))
+            if not watched_at:
+                # Skip entries that don't have a watched timestamp. These can
+                # include watchlist items or other actions that aren't actual
+                # play events and would otherwise be incorrectly synced as
+                # watched.
+                continue
             if mindate and not safe_timestamp_compare(watched_at, mindate):
                 continue
 
@@ -491,6 +497,11 @@ def get_managed_user_plex_history(account, user_id, server_name=None, mindate: O
             
             for entry in history_items:
                 watched_at = to_iso_z(getattr(entry, "viewedAt", None))
+                if not watched_at:
+                    # History entries without a viewedAt timestamp correspond
+                    # to actions such as watchlist additions. Skip them to
+                    # avoid treating unwatched items as watched.
+                    continue
                 if mindate and not safe_timestamp_compare(watched_at, mindate):
                     continue
                 
@@ -806,6 +817,10 @@ def get_server_based_history(plex, mindate: Optional[str] = None) -> Tuple[
     try:
         for entry in plex.history(mindate=mindate):
             watched_at = to_iso_z(getattr(entry, "viewedAt", None))
+            if not watched_at:
+                # Entries with no watched timestamp are not actual play
+                # events (e.g. watchlist additions) and should be ignored.
+                continue
             if mindate and not safe_timestamp_compare(watched_at, mindate):
                 continue
 

--- a/tests/test_watchlist_entries.py
+++ b/tests/test_watchlist_entries.py
@@ -1,0 +1,91 @@
+"""Tests for Plex history functions skipping unwatched items."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import plex_utils
+
+
+class MockItem(SimpleNamespace):
+    """Simple item with title and year attributes."""
+
+
+class MockEntry(SimpleNamespace):
+    """Simple history entry returned by plexapi."""
+
+    def source(self):  # pragma: no cover - simple passthrough
+        return self.item
+
+
+def test_owner_history_skips_entries_without_viewed_at(monkeypatch):
+    """Entries lacking ``viewedAt`` (e.g. watchlist additions) should be ignored."""
+
+    watched = MockEntry(
+        type="movie",
+        viewedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        item=MockItem(title="Watched", year=2024),
+    )
+    watchlist = MockEntry(
+        type="movie",
+        viewedAt=None,
+        item=MockItem(title="On Watchlist", year=2025),
+    )
+
+    account = SimpleNamespace(
+        history=lambda mindate=None, maxresults=None: [watched, watchlist],
+        server=lambda name: (_ for _ in ()).throw(Exception("no server")),
+        resources=lambda: [],
+    )
+
+    monkeypatch.setattr(
+        plex_utils, "get_cached_movie_guid", lambda title, year, item: f"imdb://{title}"
+    )
+
+    movies, episodes = plex_utils.get_owner_plex_history(account)
+    assert "imdb://Watched" in movies
+    assert "imdb://On Watchlist" not in movies
+
+
+def test_managed_user_history_skips_entries_without_viewed_at(monkeypatch):
+    """Managed user history should also ignore entries without ``viewedAt``."""
+
+    watched = MockEntry(
+        type="movie",
+        viewedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        item=MockItem(title="Watched", year=2024),
+    )
+    watchlist = MockEntry(
+        type="movie",
+        viewedAt=None,
+        item=MockItem(title="On Watchlist", year=2025),
+    )
+
+    plex_server = SimpleNamespace(
+        history=lambda accountID=None, mindate=None, maxresults=None, ratingKey=None: [
+            watched,
+            watchlist,
+        ],
+        library=SimpleNamespace(sections=lambda: []),
+    )
+
+    class MockUser:
+        id = 1
+        home = True
+        username = "user"
+
+    account = SimpleNamespace(
+        users=lambda: [MockUser()],
+        resource=lambda name: SimpleNamespace(connect=lambda: plex_server),
+        resources=lambda: [],
+    )
+
+    monkeypatch.setattr(
+        plex_utils, "get_cached_movie_guid", lambda title, year, item: f"imdb://{title}"
+    )
+
+    movies, episodes = plex_utils.get_managed_user_plex_history(
+        account, user_id=1, server_name="srv"
+    )
+    assert "imdb://Watched" in movies
+    assert "imdb://On Watchlist" not in movies
+


### PR DESCRIPTION
## Summary
- skip Plex history entries lacking `viewedAt` to avoid syncing watchlist actions as watched
- test that owner and managed user history ignore entries without a watch timestamp

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68926dc2c978832e88be095e8fd26a3a