### PR TITLE
Enable Simkl live sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ From the web interface you can download a backup file containing your Trakt hist
 When **Live Sync** is enabled on the main page, PlexyTrack will start a
 webhook endpoint at `/webhook`. Configure a Plex Webhook to call this URL and
 the application will trigger an immediate sync whenever an event is received.
+When the Simkl provider is selected, the received payload is also forwarded to
+Simkl's own `sync/plex/webhook` endpoint for instant updates.
 
 ## Getting a Plex token
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,7 +167,7 @@
                             </select>
                         </div>
                         <div class="checkbox-group">
-                            <input type="checkbox" id="live_sync" name="live_sync" {% if live_sync %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
+                            <input type="checkbox" id="live_sync" name="live_sync" {% if live_sync %}checked{% endif %}>
                             <label for="live_sync">Live Sync</label>
                         </div>
                     </fieldset>

--- a/tests/test_simkl_webhook.py
+++ b/tests/test_simkl_webhook.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+import app
+
+
+def test_webhook_forwarded_to_simkl(monkeypatch):
+    app.LIVE_SYNC = True
+    app.SYNC_PROVIDER = "simkl"
+
+    monkeypatch.setenv("SIMKL_CLIENT_ID", "cid")
+    monkeypatch.setenv("SIMKL_ACCESS_TOKEN", "token")
+
+    called = {}
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        called["url"] = url
+        called["data"] = data
+        called["headers"] = headers
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(app.requests, "post", fake_post)
+    monkeypatch.setattr(app.scheduler, "add_job", lambda *a, **k: None)
+
+    client = app.app.test_client()
+    resp = client.post("/webhook", data=b"payload", content_type="application/json")
+
+    assert resp.status_code == 204
+    assert called["url"] == "https://api.simkl.com/sync/plex/webhook?client_id=cid&token=token"
+    assert called["data"] == b"payload"
+    assert called["headers"]["Content-Type"] == "application/json"
+


### PR DESCRIPTION
## Summary
- allow live sync when Simkl is the provider
- forward Plex webhooks to Simkl and add UI/README support
- test webhook forwarding behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689274871b3c832e853d8d6b3f70cc92