### PR TITLE
Use Plex Discover endpoint for watchlist operations

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,12 @@ from plexapi.myplex import MyPlexAccount
 from plexapi.exceptions import BadRequest, NotFound
 from getpass import getpass
 
+# Plex moved watchlist and other account endpoints from the old
+# ``metadata.provider.plex.tv`` domain to ``discover.provider.plex.tv``.
+# Override the PlexAPI constant so all watchlist operations use the
+# updated base URL.
+MyPlexAccount.METADATA = MyPlexAccount.DISCOVER
+
 from utils import (
     to_iso_z,
     normalize_year,

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -7,6 +7,13 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import requests
 
+from plexapi.myplex import MyPlexAccount
+
+# Plex switched watchlist-related endpoints to the Discover domain.
+# Ensure PlexAPI uses the new base URL when this module is imported
+# independently of ``app.py``.
+MyPlexAccount.METADATA = MyPlexAccount.DISCOVER
+
 from utils import (
     guid_to_ids,
     normalize_year,


### PR DESCRIPTION
## Summary
- Update PlexAPI configuration to use `discover.provider.plex.tv` instead of deprecated metadata domain
- Ensure standalone modules patch the base URL for watchlist endpoints

## Testing
- `pytest -q`
- `curl -s -D - https://discover.provider.plex.tv/actions/addToWatchlist | head -n 10`


------
https://chatgpt.com/codex/tasks/task_e_689ef323bdc0832e817a437c138bcb19